### PR TITLE
Fixing up results from htmllint

### DIFF
--- a/src/sidebar/options/options.html
+++ b/src/sidebar/options/options.html
@@ -1,16 +1,14 @@
 <!DOCTYPE html>
-
-<html>
+<html lang="en-US">
 <head>
-  <meta charset="utf-8">
+  <meta charset="utf-8" />
+  <title>Firefox Notes Options</title>
 </head>
-
 <body>
 
-<div style="font-family: sans-serif">Redirect URL: <span id="redirect-url"></span></div>
+  <div style="font-family: sans-serif">Redirect URL: <span id="redirect-url"></span></div>
 
-<script src="options.js"></script>
+  <script src="options.js"></script>
 
 </body>
-
 </html>

--- a/src/sidebar/panel.html
+++ b/src/sidebar/panel.html
@@ -1,44 +1,49 @@
-<html>
-    <head>
-        <link href="quill.snow.css" rel="stylesheet">
-        <link href="styles.css" rel="stylesheet">
-        <style>
-          .ql-snow .ql-picker.ql-size {
-            width: 45px;
-          }
-        </style>
-    </head>
+<!DOCTYPE html>
+<html lang="en-US">
+<head>
+  <meta charset="utf-8" />
+  <title>Firefox Notes</title>
+  <link href="quill.snow.css" rel="stylesheet">
+  <link href="styles.css" rel="stylesheet">
+  <style>
+    .ql-snow .ql-picker.ql-size {
+      width: 45px;
+    }
+  </style>
+</head>
 
-    <body>
-        <!-- Create the Quill.js toolbar container -->
-        <div id="toolbar">
-          <!-- Add font size dropdown -->
-          <select class="ql-size">
-            <option value="small">12</option>
-            <!-- Note a missing, thus falsy value, is used to reset to default -->
-            <option selected>14</option>
-            <option value="large">16</option>
-            <option value="huge">18</option>
-          </select>
-          <!-- Add a bold button -->
-          <button class="ql-bold"></button>
-          <button class="ql-italic"></button>
-          <button class="ql-strike"></button>
-          <button class="ql-list" value="ordered"></button>
-          <button class="ql-list" value="bullet"></button>
-        </div>
+<body>
 
-        <!-- Create the Quill.js editor container -->
-        <div id="editor"></div>
+  <!-- Create the Quill.js toolbar container -->
+  <div id="toolbar">
+    <!-- Add font size dropdown -->
+    <select class="ql-size">
+      <option value="small">12</option>
+      <!-- Note a missing, thus falsy value, is used to reset to default -->
+      <option selected>14</option>
+      <option value="large">16</option>
+      <option value="huge">18</option>
+    </select>
+    <!-- Add a bold button -->
+    <button class="ql-bold"></button>
+    <button class="ql-italic"></button>
+    <button class="ql-strike"></button>
+    <button class="ql-list" value="ordered"></button>
+    <button class="ql-list" value="bullet"></button>
+  </div>
 
-        <!-- Add a Firefox Sync toolbar -->
-        <button id="enableSync">Enable Sync</button>
+  <!-- Create the Quill.js editor container -->
+  <div id="editor"></div>
 
-        <!-- Include the Quill library -->
-        <script src="quill.js"></script>
-        <!-- Include the kinto-http library -->
-        <script src="kinto-http.js"></script>
-        <!-- Initialize Quill editor -->
-        <script src="panel.js"></script>
-    </body>
+  <!-- Add a Firefox Sync toolbar -->
+  <button id="enable-sync">Enable Sync</button>
+
+  <!-- Include the Quill library -->
+  <script src="quill.js"></script>
+  <!-- Include the kinto-http library -->
+  <script src="kinto-http.js"></script>
+  <!-- Initialize Quill editor -->
+  <script src="panel.js"></script>
+
+</body>
 </html>

--- a/src/sidebar/panel.js
+++ b/src/sidebar/panel.js
@@ -182,6 +182,7 @@ browser.storage.local.get(["bearer", "keys", "notes"], function(data) {
 });
 
 let storageTimeout;
+
 function storeToKinto(bearer, keys, content) {
   var later = function() {
     storageTimeout = null;
@@ -218,7 +219,7 @@ quill.on("text-change", (delta, oldDelta, source) => {
   });
 });
 
-const enableSync = document.getElementById('enableSync');
+const enableSync = document.getElementById('enable-sync');
 enableSync.onclick = () => {
   browser.runtime.sendMessage({ action: 'authenticate' });
 };


### PR DESCRIPTION
Ref: #18

Still have 2 warnings regarding `<style>` tag and `style=""` attribute:

```sh
✗ $(npm bin)/htmllint 'src/**/*.html'

src/sidebar/panel.html: line 8, col 3, the style tag is banned
src/sidebar/options/options.html: line 9, col 4, the `style` attribute is banned

[htmllint] found 2 errors out of 2 files
```
---

**UPDATE:** This PR is mostly just whitespace tweaking, so the more easily digestible diff is https://github.com/mozilla/notes/pull/19/files?w=1