### PR TITLE
Fix bad button id in CSS

### DIFF
--- a/src/sidebar/styles.css
+++ b/src/sidebar/styles.css
@@ -14,7 +14,7 @@ div#editor {
   height: calc(100% - 70px);
 }
 
-button#enableSync {
+button#enable-sync {
   min-height: 30px;
 }
 


### PR DESCRIPTION
Ref: [/src/sidebar/panel.html:34](https://github.com/mozilla/notes/blob/5dd39837054c28d75bdd94e46fc1f4e5790fbd87/src/sidebar/panel.html#L34):

```html
<!-- Add a Firefox Sync toolbar -->
<button id="enable-sync">Enable Sync</button>
```