### PR TITLE
WIP : Add localization support

### DIFF
--- a/locales/en-US/notes.properties
+++ b/locales/en-US/notes.properties
@@ -1,0 +1,13 @@
+welcomeTitle=Welcome!
+welcomeText=This is a simple one-page notepad built in to Firefox that helps you get the most out of the web.
+
+emptyPlaceHolder=Take a note…
+
+openingLogin=Opening Login…
+forgetEmail=Forget this Email
+
+syncNotReady=Sorry, Sync is not ready yet, but we will count your click as a vote to hurry it up!
+syncNotes=Sync Your Notes
+syncProgress=Syncing Changes…
+disableSync=Disable Sync
+syncComplete=Synced

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "testpilot-metrics": "2.1.3"
   },
   "devDependencies": {
+    "cross-spawn": "^5.1.0",
     "eslint": "^4.0.0",
+    "pontoon-to-webext": "^1.0.2",
     "prettier": "^1.4.4",
     "rimraf": "^2.6.1",
     "web-ext": "^1.9.1"

--- a/scripts/build-locales.js
+++ b/scripts/build-locales.js
@@ -1,0 +1,18 @@
+#! /usr/bin/env node
+const spawn = require('cross-spawn');
+
+const locales = '*';
+
+const result = spawn.sync('pontoon-to-webext', [], {
+  stdio: 'inherit',
+  env: Object.assign(
+    {},
+    process.env,
+    { SUPPORTED_LOCALES: locales }
+  )
+});
+
+if (result.error) {
+  console.error(result.error); // eslint-disable-line no-console
+  process.exit(1);
+}


### PR DESCRIPTION
For https://github.com/mozilla/notes/issues/42

- [x] Add pontoon-to-webext as a dev depedency
- [x] Create a locales/en-US/notes.properties with American translations
- [x] Create a ./bin/build-locales.js script and plug it in the npm run build step.
- [ ] Create a locales directory with translations for supported locales.
- [ ]  Use browser.i18n.getMessage('slug')} everywhere we need to show a translated string.
- [ ] Try to avoid hardcoded list of locales!!! OR List supported locale in packages.json
- [ ] Add README to this repo, example: https://github.com/mozilla/activity-stream/blob/master/docs/v1-test-pilot/localization.md
- [ ] Then plug Ponton to keep locales translations in sync
- [ ] Handle langDir ltr, rtl and Configure Quill.js