### PR TITLE
feat(translations): call browser i18n for all strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ node_modules/
 web-ext-artifacts/
 src/vendor/*
 src/sidebar/vendor/*
-
+src/_locales

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -26,5 +26,7 @@ You can build the add on with a different locale by using the --pref argument to
 ```WEB_EXT_PREF=general.useragent.locale=locale_to_test npm start```
 
 ## Testing with right to left
-You can test right to left locales by building with a locale that uses RTL text direction. (e.g ar)
+You can run ```npm run start-rtl``` to start the addon with the ar locale
+
+You can also test with a custom RTL locale of your choice with
 ```WEB_EXT_PREF=general.useragent.locale=ar npm start```

--- a/locales/en-US/notes.properties
+++ b/locales/en-US/notes.properties
@@ -6,9 +6,7 @@ emptyPlaceHolder=Take a note…
 openingLogin=Opening Login…
 forgetEmail=Forget this Email
 
-# LOCALIZATION NOTE (syncNotReady): Sync is intended as a generic
-# synchronization, not Firefox Sync.
-syncNotReady=Sorry, Sync is not ready yet, but we will count your click as a vote to hurry it up!
+syncNotReady=Sorry, syncing notes isn’t ready. We will count your click as a vote to hurry it up!
 syncNotes=Sync Your Notes
 syncProgress=Syncing Changes…
 # LOCALIZATION NOTE (disableSync): Sync is intended as a generic

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "license": "MPL-2.0",
   "repository": "mozilla/notes",
   "scripts": {
-    "build": "web-ext build -s src && unzip -l web-ext-artifacts/*.zip",
+    "build": "node scripts/build-locales && web-ext build -s src && unzip -l web-ext-artifacts/*.zip",
     "clean": "rimraf web-ext-artifacts",
     "format": "prettier 'src/**/!(vendor)/*.{css,js}' --single-quote --write",
     "lint": "eslint src",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "postformat": "npm run lint -- --fix",
     "postinstall": "scripts/postinstall.sh",
     "prebuild": "npm run clean",
-    "start": "web-ext run -s src"
+    "start": "web-ext run -s src",
+    "start-rtl": "WEB_EXT_PREF=general.useragent.locale=ar npm start"
   }
 }

--- a/scripts/build-locales.js
+++ b/scripts/build-locales.js
@@ -3,7 +3,7 @@ const spawn = require('cross-spawn');
 
 const locales = '*';
 
-const result = spawn.sync('pontoon-to-webext', [], {
+const result = spawn.sync('pontoon-to-webext', ['--dest=src/_locales'], {
   stdio: 'inherit',
   env: Object.assign(
     {},

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -8,3 +8,4 @@ cp node_modules/quill/dist/quill.snow.css src/sidebar/vendor
 
 # Copy the 3rd party LICENSE files.
 cp node_modules/quill/LICENSE src/sidebar/vendor/quill.LICENSE
+node scripts/build-locales

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,6 +3,7 @@
   "name": "Firefox Notes",
   "description": "Displays a sidebar that lets you take notes on web pages.",
   "version": "1.3",
+  "default_locale": "en_US",
   "applications": {
     "gecko": {
       "id": "notes@mozilla.com",

--- a/src/sidebar/panel.html
+++ b/src/sidebar/panel.html
@@ -26,6 +26,7 @@
     <button class="ql-strike"></button>
     <button class="ql-list" value="ordered"></button>
     <button class="ql-list" value="bullet"></button>
+    <span id="ql-direction"></span>
   </div>
 
   <!-- Create the Quill.js editor container -->

--- a/src/sidebar/panel.html
+++ b/src/sidebar/panel.html
@@ -33,8 +33,8 @@
 
   <!-- Add a Firefox Sync toolbar -->
   <footer>
-    <div id="sync-note">Sorry, Sync is not ready yet, but we will count your click as a vote to hurry it up!</div>
-    <button id="enable-sync">Sync Your Notes</button>
+    <div id="sync-note"></div>
+    <button id="enable-sync"></button>
   </footer>
 
   <!-- Include the Quill library -->

--- a/src/sidebar/panel.js
+++ b/src/sidebar/panel.js
@@ -15,7 +15,7 @@ Quill.register(fontSizeStyle, true);
 
 const quill = new Quill('#editor', {
   theme: 'snow',
-  placeholder: 'Take a note...',
+  placeholder: browser.i18n.getMessage('emptyPlaceHolder'),
   modules: {
     toolbar: '#toolbar'
   },
@@ -26,12 +26,12 @@ function handleLocalContent(data) {
   if (!data.hasOwnProperty('notes')) {
     quill.setContents({
       ops: [
-        { attributes: { size: 'large', bold: true }, insert: 'Welcome!' },
+        { attributes: { size: 'large', bold: true }, insert: browser.i18n.getMessage('welcomeTitle') },
         { insert: '\n\n' },
         {
           attributes: { size: 'large' },
           insert:
-            'This is a simple one-page notepad built in to Firefox that helps you get the most out of the web.'
+            browser.i18n.getMessage('welcomeText')
         },
         { insert: '\n\n' }
       ]
@@ -68,6 +68,9 @@ quill.on('text-change', () => {
 
 const enableSync = document.getElementById('enable-sync');
 const noteDiv = document.getElementById('sync-note');
+enableSync.textContent = browser.i18n.getMessage('syncNotes');
+noteDiv.textContent = browser.i18n.getMessage('syncNotReady');
+
 
 enableSync.onclick = () => {
   noteDiv.classList.toggle('visible');

--- a/src/sidebar/panel.js
+++ b/src/sidebar/panel.js
@@ -20,6 +20,12 @@ const fontSizeStyle = Quill.import('attributors/style/size');
 fontSizeStyle.whitelist = ['12px', '14px', '16px', '18px', '20px'];
 Quill.register(fontSizeStyle, true);
 
+// add text direction icon to toolbar if RTL
+const qlDirection = document.getElementById('ql-direction');
+if (LANG_DIR === 'rtl') {
+  qlDirection.innerHTML = '<button class="ql-direction" value="rtl"></button>';
+}
+
 const quill = new Quill('#editor', {
   theme: 'snow',
   placeholder: browser.i18n.getMessage('emptyPlaceHolder'),

--- a/src/sidebar/panel.js
+++ b/src/sidebar/panel.js
@@ -6,8 +6,15 @@ const formats = [
   'strike',
   'header',
   'indent',
-  'list'
+  'list',
+  'direction',
+  'align'
 ];
+const UI_LANG = browser.i18n.getUILanguage();
+const RTL_LANGS = ['ar', 'fa', 'he'];
+const LANG_DIR = RTL_LANGS.includes(UI_LANG) ? 'rtl' : 'ltr';
+const TEXT_ALIGN_DIR = LANG_DIR === 'rtl' ? 'right' : 'left';
+
 
 const fontSizeStyle = Quill.import('attributors/style/size');
 fontSizeStyle.whitelist = ['12px', '14px', '16px', '18px', '20px'];
@@ -27,13 +34,13 @@ function handleLocalContent(data) {
     quill.setContents({
       ops: [
         { attributes: { size: 'large', bold: true }, insert: browser.i18n.getMessage('welcomeTitle') },
-        { insert: '\n\n' },
+        { insert: '\n\n', attributes: { direction: LANG_DIR, align: TEXT_ALIGN_DIR }},
         {
           attributes: { size: 'large' },
           insert:
             browser.i18n.getMessage('welcomeText')
         },
-        { insert: '\n\n' }
+        { insert: '\n\n', attributes: { direction: LANG_DIR, align: TEXT_ALIGN_DIR }}
       ]
     });
   } else {


### PR DESCRIPTION
For https://github.com/mozilla/notes/issues/42

TODO: get ltr/rtl working properly

Question:
- Should the name of the add-on be translated? i.e `notes`?