### PR TITLE
Add back Tab Authentication flow.

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1,7 +1,7 @@
 /**
  * Kinto configuration
  */
-const KINTO_SERVER = "https://kinto.dev.mozaws.net/v1";
+const KINTO_SERVER = "https://kinto-ota.dev.mozaws.net/v1";
 const REDIRECT_URL = browser.identity.getRedirectURL();
 const CLIENT_ID = 'c6d74070a481bc10';
 

--- a/src/background.js
+++ b/src/background.js
@@ -1,4 +1,12 @@
 /**
+ * Kinto configuration
+ */
+const KINTO_SERVER = "https://kinto.dev.mozaws.net/v1";
+const REDIRECT_URL = browser.identity.getRedirectURL();
+const CLIENT_ID = 'c6d74070a481bc10';
+
+
+/**
  * Google Analytics / TestPilot Metrics
  */
 const TRACKING_ID = 'UA-101177676-1';
@@ -26,11 +34,12 @@ browser.storage.local.get('UID').then((data) => {
     case 'authenticate':
       browser.storage.local.set({'asked-for-syncing': true})
       .then(() => {
-          sendEvent({
-            object: 'webext-button-authenticate',
-            method: 'click'
-          });
+        sendEvent({
+          object: 'webext-button-authenticate',
+          method: 'click'
         });
+        handleAuthentication(KINTO_SERVER, REDIRECT_URL, CLIENT_ID);
+      });
       break;
     }
   });

--- a/src/fxa-login-tab.js
+++ b/src/fxa-login-tab.js
@@ -1,0 +1,48 @@
+/**
+ * Handle Firefox Account Authentication
+ */
+/**
+ * Handle the end of the OAuth flow
+ */
+function tabCallback(redirectURL) {
+  return function(tabId, changeInfo, updatedTab) {
+    if (changeInfo.status === 'complete' && updatedTab.url.indexOf(redirectURL) === 0) {
+      chrome.tabs.remove(tabId);
+      var params = getURLParams(updatedTab.url, redirectURL);
+      chrome.storage.local.set(params, function() {
+        chrome.runtime.sendMessage({ ...params, action: 'authenticated' });
+      });
+    }
+  };
+}
+
+function getURLParams(updatedTabURL, redirectURL) {
+  console.log('getURLParams', updatedTabURL, redirectURL);
+  let parts = {};
+  const params = updatedTabURL.split(redirectURL)[1];
+  if (params.indexOf('&') !== -1) {
+    const queryparams = params.split('&');
+    for (var param in queryparams) {
+      const pairs = param.split('=', 1);
+      parts[pairs[0]] = pairs[1];
+    }
+  } else {
+    // Previous FxA version that doesn't return keys.
+    console.error('keys are missing');
+    parts.bearer = params;
+  }
+  console.log('OAuth flow params', parts);
+  return parts;
+}
+
+/**
+ * Start the login flow
+ */
+
+function handleAuthentication(kinto_server, redirectURL, client_id) {
+  const authenticateURL = `${kinto_server}/fxa-oauth/login?client_id=${client_id}&redirect=${encodeURIComponent(redirectURL)}`;
+  console.log("Starting auth.");
+  chrome.tabs.create({ 'url': authenticateURL }, function () {
+    chrome.tabs.onUpdated.addListener(tabCallback(redirectURL));
+  });
+}

--- a/src/fxa-oauth-flow.js
+++ b/src/fxa-oauth-flow.js
@@ -1,0 +1,65 @@
+function getAuthenticationURL(params) { 
+  var queryParams = {
+    client_id: params.client_id,
+    state: params.state,
+    scope: params.scope,
+    response_type: 'code',
+    code_challenge_method: 'S256',
+    code_challenge: params.code_challenge,
+    redirect_url: browser.identity.getRedirectURL()
+  };
+  return params.oauth_uri + '/authorization' + objectToQueryString(queryParams);
+}
+
+
+function createRandomString(length) {
+  if (length <= 0) {
+    return '';
+  }
+  var _state = '';
+  var possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~";
+  for (var i = 0; i < length; i++) {
+    _state += possible.charAt(Math.floor(Math.random() * possible.length));
+  }
+  return _state;
+}
+
+function sha256(str) {
+  var buffer = new TextEncoder("utf-8").encode(str);
+  return crypto.subtle.digest("SHA-256", buffer)
+    .then(digest => {
+      return btoa(String.fromCharCode.apply(null, new Uint8Array(digest)))
+        .replace(/\+/g, '-').replace(/\//g, '_').replace(/\=+$/, '');
+    });
+}
+
+/**
+ * Create a query parameter string from a key and value
+ *
+ * @method createQueryParam
+ * @param {String} key
+ * @param {Variant} value
+ * @returns {String}
+ * URL safe serialized query parameter
+ */
+function createQueryParam(key, value) {
+  return encodeURIComponent(key) + '=' + encodeURIComponent(value);
+}
+
+/**
+ * Create a query string out of an object.
+ * @method objectToQueryString
+ * @param {Object} obj
+ * Object to create query string from
+ * @returns {String}
+ * URL safe query string
+ */
+function objectToQueryString(obj) {
+  var queryParams = [];
+
+  for (var key in obj) {
+    queryParams.push(createQueryParam(key, obj[key]));
+  }
+
+  return '?' + queryParams.join('&');
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -31,6 +31,7 @@
   "background": {
     "scripts": [
       "vendor/testpilot-metrics.js",
+      "fxa-oauth-flow.js",
       "fxa-login-tab.js",
       "background.js"
     ]

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -22,6 +22,8 @@
   },
 
   "permissions": [
+    "identity",
+    "tabs",
     "storage",
     "https://ssl.google-analytics.com/collect"
   ],
@@ -29,6 +31,7 @@
   "background": {
     "scripts": [
       "vendor/testpilot-metrics.js",
+      "fxa-login-tab.js",
       "background.js"
     ]
   },


### PR DESCRIPTION
- [x] Re-enable the flow using tabs and well as identity for the redirect URL.
- [ ] Supports OAuth flow handling on the server side. (Keep the add-on code simpler) Refs https://github.com/mozilla-services/kinto-fxa/issues/49
- [ ] Add the `fxa-crypto-relier.js` part to generate the keys.