### PR TITLE
Clean src/sidebar/vendor/ directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "repository": "mozilla/notes",
   "scripts": {
     "build": "node scripts/build-locales && web-ext build -s src && unzip -l web-ext-artifacts/*.zip",
-    "clean": "rimraf web-ext-artifacts",
+    "clean": "rimraf web-ext-artifacts 'src/sidebar/vendor/!(.gitkeep)' && npm run postinstall",
     "format": "prettier 'src/**/!(vendor)/*.{css,js}' --single-quote --write",
     "lint": "eslint src",
     "postformat": "npm run lint -- --fix",


### PR DESCRIPTION
Take it or leave it, but I just realized I've been building the add-on locally with a bunch of bloated old vendor files which we aren't using anymore (which was doubling my extension size).

This should clean and rebuild the ./src/sidebar/vendor/* directory.