### PR TITLE
Add key-bindings for toolbar buttons

### DIFF
--- a/src/sidebar/panel.js
+++ b/src/sidebar/panel.js
@@ -15,6 +15,42 @@ const RTL_LANGS = ['ar', 'fa', 'he'];
 const LANG_DIR = RTL_LANGS.includes(UI_LANG) ? 'rtl' : 'ltr';
 const TEXT_ALIGN_DIR = LANG_DIR === 'rtl' ? 'right' : 'left';
 
+// Additional keyboard shortcuts for non-default toolbar buttons
+const bindings = {
+  strike: {           // ⌘/Ctrl+Shift+X
+    key: 'X',
+    shiftKey: true,
+    shortKey: true,
+    handler: function(range, context) {
+      if (this.quill.getFormat(range).strike == true)
+        this.quill.formatText(range, 'strike', false);
+      else
+        this.quill.formatText(range, 'strike', true);
+    }
+  }, ordered: {       // ⌘/Ctrl+Shift+1
+    key: '1',
+    shiftKey: true,
+    shortKey: true,
+    handler: function(range, context) {
+      console.log(this.quill.getFormat(range));
+      if (this.quill.getFormat(range).list === "ordered")
+        this.quill.formatLine(range, {'list': false}, true);
+      else
+        this.quill.formatLine(range, {'list': "ordered"}, true);
+    }
+  }, bullet: {        // ⌘/Ctrl+Shift+2
+    key: '2',
+    shiftKey: true,
+    shortKey: true,
+    handler: function(range, context) {
+      console.log(this.quill.getFormat(range));
+      if (this.quill.getFormat(range).list === "bullet")
+        this.quill.formatLine(range, {'list': false}, true);
+      else
+        this.quill.formatLine(range, {'list': "bullet"}, true);
+    }
+  }
+}
 
 const fontSizeStyle = Quill.import('attributors/style/size');
 fontSizeStyle.whitelist = ['12px', '14px', '16px', '18px', '20px'];
@@ -30,10 +66,20 @@ const quill = new Quill('#editor', {
   theme: 'snow',
   placeholder: browser.i18n.getMessage('emptyPlaceHolder'),
   modules: {
+    keyboard: {
+      bindings: bindings
+    },
     toolbar: '#toolbar'
   },
   formats: formats // enabled formats, see https://github.com/quilljs/quill/issues/1108
 });
+
+var userOSKey;
+
+if (navigator.appVersion.indexOf("Mac") != -1)
+  userOSKey = '⌘';
+else
+  userOSKey = 'Ctrl';
 
 const size = document.getElementsByClassName('ql-size')[0],
       bold = document.getElementsByClassName('ql-bold')[0],
@@ -44,11 +90,11 @@ const size = document.getElementsByClassName('ql-size')[0],
 
 // Setting button titles in place of tooltips
 size.title = browser.i18n.getMessage('fontSizeTitle');
-bold.title = browser.i18n.getMessage('boldTitle');
-italic.title = browser.i18n.getMessage('italicTitle');
-strike.title = browser.i18n.getMessage('strikethroughTitle');
-ordered.title = browser.i18n.getMessage('numberedListTitle');
-bullet.title = browser.i18n.getMessage('bulletedListTitle');
+bold.title = browser.i18n.getMessage('boldTitle') + "(" + userOSKey + "+B)";
+italic.title = browser.i18n.getMessage('italicTitle') + "(" + userOSKey + "+I)";
+strike.title = browser.i18n.getMessage('strikethroughTitle') + "(" + userOSKey + "+Shift+" + bindings.strike.key + ")";
+ordered.title = browser.i18n.getMessage('numberedListTitle') + "(" + userOSKey + "+Shift+" + bindings.ordered.key + ")";
+bullet.title = browser.i18n.getMessage('bulletedListTitle') + "(" + userOSKey + "+Shift+" + bindings.bullet.key + ")";
 qlDirection.title = browser.i18n.getMessage('textDirectionTitle');
 
 function handleLocalContent(data) {

--- a/src/sidebar/panel.js
+++ b/src/sidebar/panel.js
@@ -21,8 +21,8 @@ const bindings = {
     key: 'X',
     shiftKey: true,
     shortKey: true,
-    handler: function(range, context) {
-      if (this.quill.getFormat(range).strike == true)
+    handler: function(range) {
+      if (this.quill.getFormat(range).strike === true)
         this.quill.formatText(range, 'strike', false);
       else
         this.quill.formatText(range, 'strike', true);
@@ -31,26 +31,24 @@ const bindings = {
     key: '1',
     shiftKey: true,
     shortKey: true,
-    handler: function(range, context) {
-      console.log(this.quill.getFormat(range));
-      if (this.quill.getFormat(range).list === "ordered")
+    handler: function(range) {
+      if (this.quill.getFormat(range).list === 'ordered')
         this.quill.formatLine(range, {'list': false}, true);
       else
-        this.quill.formatLine(range, {'list': "ordered"}, true);
+        this.quill.formatLine(range, {'list': 'ordered'}, true);
     }
   }, bullet: {        // ⌘/Ctrl+Shift+2
     key: '2',
     shiftKey: true,
     shortKey: true,
-    handler: function(range, context) {
-      console.log(this.quill.getFormat(range));
-      if (this.quill.getFormat(range).list === "bullet")
+    handler: function(range) {
+      if (this.quill.getFormat(range).list === 'bullet')
         this.quill.formatLine(range, {'list': false}, true);
       else
-        this.quill.formatLine(range, {'list': "bullet"}, true);
+        this.quill.formatLine(range, {'list': 'bullet'}, true);
     }
   }
-}
+};
 
 const fontSizeStyle = Quill.import('attributors/style/size');
 fontSizeStyle.whitelist = ['12px', '14px', '16px', '18px', '20px'];
@@ -74,9 +72,9 @@ const quill = new Quill('#editor', {
   formats: formats // enabled formats, see https://github.com/quilljs/quill/issues/1108
 });
 
-var userOSKey;
+let userOSKey;
 
-if (navigator.appVersion.indexOf("Mac") != -1)
+if (navigator.appVersion.indexOf('Mac') !== -1)
   userOSKey = '⌘';
 else
   userOSKey = 'Ctrl';
@@ -90,11 +88,11 @@ const size = document.getElementsByClassName('ql-size')[0],
 
 // Setting button titles in place of tooltips
 size.title = browser.i18n.getMessage('fontSizeTitle');
-bold.title = browser.i18n.getMessage('boldTitle') + "(" + userOSKey + "+B)";
-italic.title = browser.i18n.getMessage('italicTitle') + "(" + userOSKey + "+I)";
-strike.title = browser.i18n.getMessage('strikethroughTitle') + "(" + userOSKey + "+Shift+" + bindings.strike.key + ")";
-ordered.title = browser.i18n.getMessage('numberedListTitle') + "(" + userOSKey + "+Shift+" + bindings.ordered.key + ")";
-bullet.title = browser.i18n.getMessage('bulletedListTitle') + "(" + userOSKey + "+Shift+" + bindings.bullet.key + ")";
+bold.title = browser.i18n.getMessage('boldTitle') + '(' + userOSKey + '+B)';
+italic.title = browser.i18n.getMessage('italicTitle') + '(' + userOSKey + '+I)';
+strike.title = browser.i18n.getMessage('strikethroughTitle') + '(' + userOSKey + '+Shift+' + bindings.strike.key + ')';
+ordered.title = browser.i18n.getMessage('numberedListTitle') + '(' + userOSKey + '+Shift+' + bindings.ordered.key + ')';
+bullet.title = browser.i18n.getMessage('bulletedListTitle') + '(' + userOSKey + '+Shift+' + bindings.bullet.key + ')';
 qlDirection.title = browser.i18n.getMessage('textDirectionTitle');
 
 function handleLocalContent(data) {


### PR DESCRIPTION
This commit is a quick fix to issue #72 - missing tooltips. Currently, Quill
has no support for native tooltips, rather relying on Bootstrap (which requires
jQuery). For usability purposes, I've added titles to the toolbar buttons
which appear when hovering over the buttons, similar to a tooltip but not as
styled. The titles themselves include the button's functionality ('Font size',
'Bold', 'Bulleted list', etc.) as well as the key-binding associated with it.

Currently, only the 'Bold' and 'Italic' formats included a default key-binding.
Following the documentation for adding additional bindings to the keyboard
module (found here: https://quilljs.com/docs/modules/keyboard/), I went ahead
and added three bindings for the buttons/formats in the toolbar without them
('strike', 'list: ordered', 'list: bulleted'). By determining the user's operating
system, the titles display the appropriate key for the binding sequence (either
Mac's Cmd symbol or 'Ctrl').

Note: This is my first pull-request for an open source project so any advice and
feedback is much appreciated!