### PR TITLE
"Close" button for the "Sync Your Notes" notification, fixes #115

### DIFF
--- a/src/sidebar/panel.html
+++ b/src/sidebar/panel.html
@@ -34,7 +34,16 @@
 
   <!-- Add a Firefox Sync toolbar -->
   <footer>
-    <div id="sync-note"></div>
+    <div id="sync-note">
+      
+      <div id="close">
+        <span id="close-button">&times;</span>
+      </div>
+      
+      <p id="sync-note-dialogue"></p>
+    </div>
+    
+    
     <button id="enable-sync"></button>
   </footer>
 

--- a/src/sidebar/panel.html
+++ b/src/sidebar/panel.html
@@ -37,7 +37,7 @@
     <div id="sync-note">
       
       <div id="close">
-        <span id="close-button">&times;</span>
+        <img src="close.svg" id="close-button"/>
       </div>
       
       <p id="sync-note-dialogue"></p>

--- a/src/sidebar/panel.js
+++ b/src/sidebar/panel.js
@@ -81,11 +81,10 @@ quill.on('text-change', () => {
 
 const enableSync = document.getElementById('enable-sync');
 const noteDiv = document.getElementById('sync-note');
+const syncNoteBody = document.getElementById('sync-note-dialogue');
 const closeButton = document.getElementById('close-button');
 enableSync.textContent = browser.i18n.getMessage('syncNotes');
-
-//todo: add const for sync-note-p
-document.getElementById('sync-note-dialogue').textContent = browser.i18n.getMessage('syncNotReady');
+syncNoteBody.textContent = browser.i18n.getMessage('syncNotReady');
 
 closeButton.addEventListener('click', () => {
   noteDiv.classList.toggle('visible');

--- a/src/sidebar/panel.js
+++ b/src/sidebar/panel.js
@@ -81,9 +81,15 @@ quill.on('text-change', () => {
 
 const enableSync = document.getElementById('enable-sync');
 const noteDiv = document.getElementById('sync-note');
+const closeButton = document.getElementById('close-button');
 enableSync.textContent = browser.i18n.getMessage('syncNotes');
-noteDiv.textContent = browser.i18n.getMessage('syncNotReady');
 
+//todo: add const for sync-note-p
+document.getElementById('sync-note-dialogue').textContent = browser.i18n.getMessage('syncNotReady');
+
+closeButton.addEventListener('click', () => {
+  noteDiv.classList.toggle('visible');
+});
 
 enableSync.onclick = () => {
   noteDiv.classList.toggle('visible');

--- a/src/sidebar/styles.css
+++ b/src/sidebar/styles.css
@@ -89,15 +89,16 @@ footer {
 }
 
 #close {
-  width: 100%;
+  float: right;
   position: relative;
   margin: 0 auto;
 }
 
 #close-button {
-  width: 14px;  
+  width: 14px;
   position: absolute;
-  right: 5px;
+  top: -8px;
+  right: 0px;
 }
 
 #close-button:hover {
@@ -105,7 +106,6 @@ footer {
 }
 
 #sync-note-dialogue {
-  margin: 4px auto 0px auto;
   width: 100%;
   color: #424242;
 }

--- a/src/sidebar/styles.css
+++ b/src/sidebar/styles.css
@@ -86,6 +86,33 @@ footer {
   padding: 15px 4%;
   background: #FFECAD;
   width: 92%;
+}
+
+#sync-note #close {
+  text-align: right;
+}
+
+#close {
+/*  border: solid blue 1px;*/
+  width: 100%;
+  display: inline-block;
+  float: right;
+}
+
+#close-button {
+  padding: 0 3px;
+}
+
+#close-button:hover {
+  cursor: default;
+  background: #5f4900;
+  color: #fffefa;
+  border: solid #5f4900 1px;
+  border-radius: 10%;
+}
+
+#sync-note-dialogue {
+  width: 100%;
   color: #424242;
 }
 

--- a/src/sidebar/styles.css
+++ b/src/sidebar/styles.css
@@ -83,35 +83,29 @@ footer {
 
 #sync-note {
   display: none;
-  padding: 15px 4%;
+  padding: 8px 4% 15px 4%;
   background: #FFECAD;
   width: 92%;
 }
 
-#sync-note #close {
-  text-align: right;
-}
-
 #close {
-/*  border: solid blue 1px;*/
   width: 100%;
-  display: inline-block;
-  float: right;
+  position: relative;
+  margin: 0 auto;
 }
 
 #close-button {
-  padding: 0 3px;
+  width: 14px;  
+  position: absolute;
+  right: 5px;
 }
 
 #close-button:hover {
-  cursor: default;
-  background: #5f4900;
-  color: #fffefa;
-  border: solid #5f4900 1px;
-  border-radius: 10%;
+  cursor: pointer;
 }
 
 #sync-note-dialogue {
+  margin: 4px auto 0px auto;
   width: 100%;
   color: #424242;
 }


### PR DESCRIPTION
This a solution for issue #115. Currently, the only way to close the notification is by clicking the "Sync Your Notes" button again.

With this PR, the `close.svg` file has been added to the top-right corner of the notification. When clicked, the notification then disappears. This allows for a more user-friendly experience.