### PR TITLE
Handle breaklines on shift-enter and copy/paste from a text area.

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -20,7 +20,7 @@ browser.storage.local.get('UID').then((data) => {
   });
 
   sendEvent({ object: 'webext-loaded', method: 'click' });
-  
+
   browser.runtime.onMessage.addListener(function(eventData) {
   switch (eventData.action) {
     case 'authenticate':

--- a/src/sidebar/panel.html
+++ b/src/sidebar/panel.html
@@ -35,15 +35,15 @@
   <!-- Add a Firefox Sync toolbar -->
   <footer>
     <div id="sync-note">
-      
+
       <div id="close">
         <img src="close.svg" id="close-button"/>
       </div>
-      
+
       <p id="sync-note-dialog"></p>
     </div>
-    
-    
+
+
     <button id="enable-sync"></button>
   </footer>
 

--- a/src/sidebar/styles.css
+++ b/src/sidebar/styles.css
@@ -45,6 +45,10 @@ div#editor {
   margin-left: -5px;
 }
 
+.ql-editor p {
+	margin-bottom: 10px;
+}
+
 /**
 Footer Styles
  */


### PR DESCRIPTION
Fixes #127 