### PR TITLE
Use a no-drop pointer when dragging into the ql-editor.

### DIFF
--- a/src/sidebar/panel.js
+++ b/src/sidebar/panel.js
@@ -122,7 +122,19 @@ chrome.runtime.onMessage.addListener(eventData => {
 
 // disable drop of links and images into notes
 const qlEditor = document.querySelectorAll('.ql-editor');
-qlEditor[0].addEventListener('drop', (e) => {
+
+document.addEventListener('dragover', () => {
+  qlEditor[0].classList.add('forbid-cursor');
+  return true;
+});
+
+document.addEventListener('dragleave', () => {
+  qlEditor[0].classList.remove('forbid-cursor');
+  return true;
+});
+
+document.addEventListener('drop', (e) => {
   e.preventDefault();
+  qlEditor[0].classList.remove('forbid-cursor');
   return false;
 });

--- a/src/sidebar/styles.css
+++ b/src/sidebar/styles.css
@@ -115,5 +115,5 @@ footer {
 }
 
 .forbid-cursor {
-  cursor: no-drop !important;
+  cursor: no-drop;
 }

--- a/src/sidebar/styles.css
+++ b/src/sidebar/styles.css
@@ -113,3 +113,7 @@ footer {
 #sync-note.visible {
   display: block;
 }
+
+.forbid-cursor {
+  cursor: no-drop !important;
+}


### PR DESCRIPTION
Fixes #132 

Apparently it doesn't work properly. I filed https://github.com/quilljs/quill/issues/1582 about it.