### PR TITLE
Fixed margin issue with Sync note on different browsers

### DIFF
--- a/src/sidebar/styles.css
+++ b/src/sidebar/styles.css
@@ -83,9 +83,9 @@ footer {
 
 #sync-note {
   display: none;
-  padding: 8px 4% 15px 4%;
+  padding: 8px 0% 15px 0%;
   background: #FFECAD;
-  width: 92%;
+  width: 100%;
 }
 
 #close {
@@ -99,6 +99,7 @@ footer {
   position: absolute;
   top: -8px;
   right: 0px;
+  margin-right: 2%;
 }
 
 #close-button:hover {
@@ -106,7 +107,8 @@ footer {
 }
 
 #sync-note-dialog {
-  width: 100%;
+  width: 92%;
+  margin: 0 10px;
   color: #424242;
 }
 

--- a/src/sidebar/styles.css
+++ b/src/sidebar/styles.css
@@ -83,7 +83,7 @@ footer {
 
 #sync-note {
   display: none;
-  padding: 8px 0% 15px 0%;
+  padding: 8px 0 15px 0;
   background: #FFECAD;
   width: 100%;
 }


### PR DESCRIPTION
## Description:
Just downloaded Firefox Dev edition and started testing Notes on there. When
opening up the Sync note, I saw that there was a great deal of margin to it's
right (the note was not the full width of the sidebar like the Sync button).

On the regular edition of Firefox, the Sync note **was** the full width of the
sidebar. These small changes make it so that the Sync note is the full width of
the sidebar on both browsers.

## Images

**FF Dev edition - before:**
![image](https://user-images.githubusercontent.com/16343560/28146519-5e46dde4-672f-11e7-934c-fc72571d420b.png)

**FF regular edition - before:**
![image](https://user-images.githubusercontent.com/16343560/28146526-79719708-672f-11e7-8051-133346710b9c.png)


**FF Dev edition - after:**
![image](https://user-images.githubusercontent.com/16343560/28147002-78f0fc76-6732-11e7-83f0-d643a9e46288.png)

**FF regular edition - after:**
![image](https://user-images.githubusercontent.com/16343560/28147033-9e0d2e26-6732-11e7-98fb-ed45fe48becb.png)