### PR TITLE
Handle open and close events.

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -42,30 +42,12 @@ An event fired when the user actively navigates to the Notes sidebar. Includes:
 
 - `ec` - `notes`
 - `ea` - `open`
-- `cm1`
-- `cm2`
-- `cd1`
-- `cd2`
-- `cd3`
-- `cd4`
-- `cd5`
-- `cd6`
-- `cd7`
 
 #### `close`
 An event fired when the user actively navigates away from the Notes sidebar. Includes:
 
 - `ec` - `notes`
 - `ea` - `close`
-- `cm1`
-- `cm2`
-- `cd1`
-- `cd2`
-- `cd3`
-- `cd4`
-- `cd5`
-- `cd6`
-- `cd7`
 
 #### `changed`
 An event fired when the user completes a change of the content of the notepad. It prospectively begins when a user focuses on the notepad's editable area, and ends when the user either 1) closes the sidebar, or 2) does not make any changes in 20 seconds. Includes:

--- a/src/background.js
+++ b/src/background.js
@@ -36,8 +36,6 @@ function sendMetrics(event, context = {}) {
   timeouts[event] = setTimeout(later, 20000);
 }
 
-// Skip the first changed event.
-let first = true;
 browser.runtime.onMessage.addListener(function(eventData) {
   switch (eventData.action) {
     case 'authenticate':
@@ -46,21 +44,22 @@ browser.runtime.onMessage.addListener(function(eventData) {
           sendMetrics('sync-started', eventData.context);
         });
       break;
-    case 'metrics-open':
-      sendMetrics('open', eventData.context);
-      break;
-    case 'metrics-close':
-      sendMetrics('close', eventData.context);
-      break;
     case 'metrics-changed':
-      if (first) {
-        first = false;
-      } else {
-        sendMetrics('changed', eventData.context);
-      }
+      sendMetrics('changed', eventData.context);
       break;
     case 'metrics-drag-n-drop':
       sendMetrics('drag-n-drop', eventData.context);
       break;
   }
 });
+
+
+// Handle opening and closing the add-on.
+function connected(p) {
+  sendMetrics('open');
+
+  p.onDisconnect.addListener(() => {
+    sendMetrics('close');
+  });
+}
+browser.runtime.onConnect.addListener(connected);

--- a/src/sidebar/panel.js
+++ b/src/sidebar/panel.js
@@ -133,10 +133,6 @@ function loadContent() {
 loadContent()
   .then(() => {
     document.getElementById('loading').style.display = 'none';
-    browser.runtime.sendMessage({
-      action: 'metrics-open',
-      context: getPadStats()
-    });
   });
 
 let ignoreNextLoadEvent = false;
@@ -245,3 +241,7 @@ function getPadStats() {
     usesList: styles.list
   };
 }
+
+// Create a connection with the background script to handle open and
+// close events.
+browser.runtime.connect();


### PR DESCRIPTION
This uses Port to handle open and close events. It works really gracefully.

However with this implementation open and close events doesn't have metrics about the content of the pad anymore because we don't have that information anymore when the pad is close. 

@chuckharmston can you tell us if it is acceptable?