### PR TITLE
Add l10n.toml

### DIFF
--- a/l10n.toml
+++ b/l10n.toml
@@ -1,0 +1,12 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+basepath = "."
+
+[env]
+    l = "{l10n_base}/locales/{locale}/"
+
+[[paths]]
+    reference = "locales/en-US/**"
+    l10n = "{l}**"


### PR DESCRIPTION
This allows to run compare-locales in the Notes repo, check for errors in locales

```
compare-locales l10n.toml . `ls locales/`
```