### PR TITLE
Truncated Sync button, fixes #153

### DIFF
--- a/src/sidebar/styles.css
+++ b/src/sidebar/styles.css
@@ -94,6 +94,10 @@ footer {
   flex: 1 0;
   padding: 0 10px 0 32px;
   text-align: left;
+  display: block;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 #give-feedback {


### PR DESCRIPTION
Adds the ellipsis ('...') to the end of the Sync button text when the sidebar is resized.

Tested on regular FF and FF Dev edition, as well as normal and RTL mode.