### PR TITLE
Context Menu for Footer

### DIFF
--- a/locales/en-US/notes.properties
+++ b/locales/en-US/notes.properties
@@ -4,6 +4,7 @@ welcomeText2=Welcome to this one-page notepad built in to Firefox. Browse the we
 emptyPlaceHolder=Take a note…
 
 giveFeedback=Click here to give us some feedback
+feedback=Feedback
 
 openingLogin=Opening Login…
 forgetEmail=Forget this Email

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/mozilla/notes/issues"
   },
   "dependencies": {
-    "material-design-lite": "^1.3.0",
+    "material-design-lite": "1.3.0",
     "quill": "1.2.6",
     "testpilot-ga": "^0.2.1"
   },

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "url": "https://github.com/mozilla/notes/issues"
   },
   "dependencies": {
+    "material-design-lite": "^1.3.0",
     "quill": "1.2.6",
     "testpilot-ga": "^0.2.1"
   },

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -8,7 +8,8 @@ const files = [
   copySync('node_modules/quill/dist/quill.snow.css', 'src/sidebar/vendor/quill.snow.css'),
   copySync('node_modules/quill/LICENSE', 'src/sidebar/vendor/quill.LICENSE'),
   copySync('node_modules/material-design-lite/material.min.js', 'src/sidebar/vendor/material.js'),
-  copySync('node_modules/material-design-lite/material.min.css', 'src/sidebar/vendor/material.css')
+  copySync('node_modules/material-design-lite/material.min.css', 'src/sidebar/vendor/material.css'),
+  copySync('node_modules/material-design-lite/LICENSE', 'src/sidebar/vendor/material.LICENSE')
 ];
 
 Promise.all(files).catch(err => {

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -6,7 +6,9 @@ const files = [
   copySync('node_modules/testpilot-ga/dist/index.js', 'src/vendor/testpilot-ga.js'),
   copySync('node_modules/quill/dist/quill.min.js', 'src/sidebar/vendor/quill.js'),
   copySync('node_modules/quill/dist/quill.snow.css', 'src/sidebar/vendor/quill.snow.css'),
-  copySync('node_modules/quill/LICENSE', 'src/sidebar/vendor/quill.LICENSE')
+  copySync('node_modules/quill/LICENSE', 'src/sidebar/vendor/quill.LICENSE'),
+  copySync('node_modules/material-design-lite/material.min.js', 'src/sidebar/vendor/material.js'),
+  copySync('node_modules/material-design-lite/material.min.css', 'src/sidebar/vendor/material.css')
 ];
 
 Promise.all(files).catch(err => {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -22,6 +22,7 @@
   },
   "permissions": [
     "storage",
+    "tabs",
     "https://ssl.google-analytics.com/collect"
   ],
   "background": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -22,7 +22,6 @@
   },
   "permissions": [
     "storage",
-    "tabs",
     "https://ssl.google-analytics.com/collect"
   ],
   "background": {

--- a/src/sidebar/dark-svg/three-dots-dark.svg
+++ b/src/sidebar/dark-svg/three-dots-dark.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="2px" height="10px" viewBox="0 0 2 10" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 44.1 (41455) - http://www.bohemiancoding.com/sketch -->
+    <title>Group</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Group" fill="#e6e6e6">
+            <rect id="Rectangle" x="0" y="4" width="2" height="2"></rect>
+            <rect id="Rectangle" x="0" y="8" width="2" height="2"></rect>
+            <rect id="Rectangle" x="0" y="0" width="2" height="2"></rect>
+        </g>
+    </g>
+</svg>

--- a/src/sidebar/panel.html
+++ b/src/sidebar/panel.html
@@ -4,10 +4,8 @@
   <meta charset="utf-8" />
   <title>Firefox Notes</title>
   <link href="vendor/quill.snow.css" rel="stylesheet">
+  <link rel="stylesheet" href="vendor/material.css">
   <link href="styles.css" rel="stylesheet">
-
-	<link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
-	<link rel="stylesheet" href="vendor/material.css">
 </head>
 
 <body>
@@ -45,17 +43,13 @@
 
     <div id="footer-buttons">
       <button id="enable-sync"></button>
-			<div class="wrapper">
-				<button id="demo-menu-top-right"
-        class="mdl-js-button">
-					<i class="material-icons">more_vert</i>
-				</button>
-				<ul class="mdl-menu mdl-menu--top-right mdl-js-menu"
-    data-mdl-for="demo-menu-top-right">
-					<li id="give-feedback" class="mdl-menu__item"></li>
-					<li id="disable-sync" class="mdl-menu__item"></li>
-				</ul>
-			</div>
+      <div class="wrapper">
+        <button id="context-menu-button" class="mdl-js-button"></button>
+        <ul class="mdl-menu mdl-menu--top-right mdl-js-menu context-menu" data-mdl-for="context-menu-button">
+          <li id="give-feedback" class="mdl-menu__item context-menu-item"></li>
+          <li id="disable-sync" class="mdl-menu__item context-menu-item"></li>
+        </ul>
+      </div>
     </div>
   </footer>
 

--- a/src/sidebar/panel.html
+++ b/src/sidebar/panel.html
@@ -45,7 +45,6 @@
 
     <div id="footer-buttons">
       <button id="enable-sync"></button>
-<!--      <a target="_blank" id="give-feedback"></a>-->
 			<div class="wrapper">
 				<button id="demo-menu-top-right"
         class="mdl-js-button">
@@ -53,8 +52,8 @@
 				</button>
 				<ul class="mdl-menu mdl-menu--top-right mdl-js-menu"
     data-mdl-for="demo-menu-top-right">
-					<li class="mdl-menu__item">Feedback</li>
-					<li class="mdl-menu__item">Disable Sync</li>
+					<li id="give-feedback" class="mdl-menu__item"></li>
+					<li id="disable-sync" class="mdl-menu__item"></li>
 				</ul>
 			</div>
     </div>

--- a/src/sidebar/panel.html
+++ b/src/sidebar/panel.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8" />
   <title>Firefox Notes</title>
+  <link href="vendor/material.css" rel="stylesheet">
   <link href="vendor/quill.snow.css" rel="stylesheet">
-  <link rel="stylesheet" href="vendor/material.css">
   <link href="styles.css" rel="stylesheet">
 </head>
 
@@ -47,7 +47,6 @@
         <button id="context-menu-button" class="mdl-js-button"></button>
         <ul class="mdl-menu mdl-menu--top-right mdl-js-menu context-menu" data-mdl-for="context-menu-button">
           <li id="give-feedback" class="mdl-menu__item context-menu-item"></li>
-          <li id="disable-sync" class="mdl-menu__item context-menu-item"></li>
         </ul>
       </div>
     </div>

--- a/src/sidebar/panel.html
+++ b/src/sidebar/panel.html
@@ -5,6 +5,9 @@
   <title>Firefox Notes</title>
   <link href="vendor/quill.snow.css" rel="stylesheet">
   <link href="styles.css" rel="stylesheet">
+
+	<link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+	<link rel="stylesheet" href="vendor/material.css">
 </head>
 
 <body>
@@ -42,7 +45,18 @@
 
     <div id="footer-buttons">
       <button id="enable-sync"></button>
-      <a target="_blank" id="give-feedback"></a>
+<!--      <a target="_blank" id="give-feedback"></a>-->
+			<div class="wrapper">
+				<button id="demo-menu-top-right"
+        class="mdl-js-button">
+					<i class="material-icons">more_vert</i>
+				</button>
+				<ul class="mdl-menu mdl-menu--top-right mdl-js-menu"
+    data-mdl-for="demo-menu-top-right">
+					<li class="mdl-menu__item">Feedback</li>
+					<li class="mdl-menu__item">Disable Sync</li>
+				</ul>
+			</div>
     </div>
   </footer>
 
@@ -50,5 +64,6 @@
   <script src="vendor/quill.js"></script>
   <!-- Initialize Quill editor -->
   <script src="panel.js"></script>
+  <script defer src="vendor/material.js"></script>
 </body>
 </html>

--- a/src/sidebar/panel.js
+++ b/src/sidebar/panel.js
@@ -163,10 +163,16 @@ enableSync.textContent = browser.i18n.getMessage('syncNotes');
 syncNoteBody.textContent = browser.i18n.getMessage('syncNotReady2');
 
 const giveFeedback = document.getElementById('give-feedback');
-giveFeedback.innerHTML = browser.i18n.getMessage('feedback');
+giveFeedback.textContent = browser.i18n.getMessage('feedback');
+giveFeedback.addEventListener('click', () => {
+  browser.tabs.create({
+    active: true,
+    url: SURVEY_PATH
+  });
+});
 
 const disableSync = document.getElementById('disable-sync');
-disableSync.innerHTML = browser.i18n.getMessage('disableSync');
+disableSync.textContent = browser.i18n.getMessage('disableSync');
 
 closeButton.addEventListener('click', () => {
   noteDiv.classList.toggle('visible');

--- a/src/sidebar/panel.js
+++ b/src/sidebar/panel.js
@@ -171,9 +171,6 @@ giveFeedback.addEventListener('click', () => {
   });
 });
 
-const disableSync = document.getElementById('disable-sync');
-disableSync.textContent = browser.i18n.getMessage('disableSync');
-
 closeButton.addEventListener('click', () => {
   noteDiv.classList.toggle('visible');
 });

--- a/src/sidebar/panel.js
+++ b/src/sidebar/panel.js
@@ -156,14 +156,17 @@ quill.on('text-change', () => {
 });
 
 const enableSync = document.getElementById('enable-sync');
-// const giveFeedback = document.getElementById('give-feedback');
 const noteDiv = document.getElementById('sync-note');
 const syncNoteBody = document.getElementById('sync-note-dialog');
 const closeButton = document.getElementById('close-button');
 enableSync.textContent = browser.i18n.getMessage('syncNotes');
 syncNoteBody.textContent = browser.i18n.getMessage('syncNotReady2');
-// giveFeedback.setAttribute('title', browser.i18n.getMessage('giveFeedback'));
-// giveFeedback.setAttribute('href', SURVEY_PATH);
+
+const giveFeedback = document.getElementById('give-feedback');
+giveFeedback.innerHTML = browser.i18n.getMessage('feedback');
+
+const disableSync = document.getElementById('disable-sync');
+disableSync.innerHTML = browser.i18n.getMessage('disableSync');
 
 closeButton.addEventListener('click', () => {
   noteDiv.classList.toggle('visible');

--- a/src/sidebar/panel.js
+++ b/src/sidebar/panel.js
@@ -156,14 +156,14 @@ quill.on('text-change', () => {
 });
 
 const enableSync = document.getElementById('enable-sync');
-const giveFeedback = document.getElementById('give-feedback');
+// const giveFeedback = document.getElementById('give-feedback');
 const noteDiv = document.getElementById('sync-note');
 const syncNoteBody = document.getElementById('sync-note-dialog');
 const closeButton = document.getElementById('close-button');
 enableSync.textContent = browser.i18n.getMessage('syncNotes');
 syncNoteBody.textContent = browser.i18n.getMessage('syncNotReady2');
-giveFeedback.setAttribute('title', browser.i18n.getMessage('giveFeedback'));
-giveFeedback.setAttribute('href', SURVEY_PATH);
+// giveFeedback.setAttribute('title', browser.i18n.getMessage('giveFeedback'));
+// giveFeedback.setAttribute('href', SURVEY_PATH);
 
 closeButton.addEventListener('click', () => {
   noteDiv.classList.toggle('visible');

--- a/src/sidebar/styles-dark.css
+++ b/src/sidebar/styles-dark.css
@@ -10,10 +10,6 @@ div#toolbar {
   background-image: url('dark-svg/sync-16-dark.svg');
 }
 
-#give-feedback {
-  background-image: url('dark-svg/feedback-dark.svg');
-}
-
 #footer-buttons button,
 #footer-buttons a {
   background-color: #272B35;
@@ -34,6 +30,29 @@ div#toolbar {
 ::-moz-selection {
   background-color: #5675B9;
   color: #fff;
+}
+
+/* material-design-lite menu */
+.mdl-menu__outline {
+  background: #272B35;
+  transition: none;
+}
+
+#context-menu-button {
+  background-image: url('dark-svg/three-dots-dark.svg');
+}
+
+.context-menu-item {
+  color: #e6e6e6;
+  background-color: #272B35;
+}
+
+.context-menu-item:hover {
+  background-color: #323744;
+}
+
+.context-menu-item:active {
+  background-color: #3d4352;
 }
 
 /* Overridden Quill classes */

--- a/src/sidebar/styles.css
+++ b/src/sidebar/styles.css
@@ -100,18 +100,6 @@ footer {
   text-overflow: ellipsis;
 }
 
-/*
-#give-feedback {
-  background-image: url('feedback.svg');
-  background-position: center center;
-  background-repeat: no-repeat;
-  background-size: 20px 20px;
-  border-left: 1px solid #d7d7db;
-  display: flex;
-  flex: 0 0 40px;
-}
-*/
-
 #footer-buttons button,
 #footer-buttons a {
   background-color: #f9f9fa;

--- a/src/sidebar/styles.css
+++ b/src/sidebar/styles.css
@@ -177,3 +177,11 @@ footer {
 .forbid-cursor {
   cursor: no-drop;
 }
+
+.mdl-js-button {
+	height: 100%;
+}
+
+.mdl-menu {
+	padding: 0;
+}

--- a/src/sidebar/styles.css
+++ b/src/sidebar/styles.css
@@ -180,6 +180,24 @@ footer {
   cursor: no-drop;
 }
 
-.mdl-js-button {
+#context-menu-button {
+  background-size: 3px;
+  background-image: url('three-dots.svg');
+  background-position:  50%;
+  background-repeat: no-repeat;
   height: 100%;
+  width: 26px;
+  text-align: left;
+}
+
+.context-menu {
+  font-family: inherit;
+  padding: 0;
+}
+
+.context-menu-item {
+  font-size: 12px;
+  padding: 0 0 0 15px;
+  height: 18px;
+  line-height: 30px;
 }

--- a/src/sidebar/styles.css
+++ b/src/sidebar/styles.css
@@ -100,6 +100,7 @@ footer {
   text-overflow: ellipsis;
 }
 
+/*
 #give-feedback {
   background-image: url('feedback.svg');
   background-position: center center;
@@ -109,6 +110,7 @@ footer {
   display: flex;
   flex: 0 0 40px;
 }
+*/
 
 #footer-buttons button,
 #footer-buttons a {
@@ -179,9 +181,5 @@ footer {
 }
 
 .mdl-js-button {
-	height: 100%;
-}
-
-.mdl-menu {
-	padding: 0;
+  height: 100%;
 }


### PR DESCRIPTION
This adds the context menu for #208. Currently, the menu looks like so:
![screen shot 2017-09-19 at 11 06 05 am](https://user-images.githubusercontent.com/16343560/30607664-9ea29b68-9d2a-11e7-867a-3b9f582cc5a3.png)

Work that still needs to be completed: 
- [x] dynamically load menu items (see next todo) - **completed: aa65927**
- [x] use translations instead of hard-coded strings for menu items - **completed: aa65927**
- [x] `eventListener`'s for menu items:
  - [x] 'Feedback' - **completed: 4f7f72d**
  ~- [ ] 'Disable Sync'~
- [x] styling for dark theme - **completed: 8775c0b**
- [x] styling that more closely matches @ryanfeeley's design
- [x] clean up code styling (tabs -> spaces; empty lines) - **completed: 23e0989**