### PR TITLE
Fixes issue #277:Add option to underline the text at the top panel

### DIFF
--- a/src/sidebar/panel.html
+++ b/src/sidebar/panel.html
@@ -24,6 +24,7 @@
     <!-- Add a bold button -->
     <button class="ql-bold"></button>
     <button class="ql-italic"></button>
+    <button class="ql-underline"></button>
     <button class="ql-strike"></button>
     <button class="ql-list" value="ordered"></button>
     <button class="ql-list" value="bullet"></button>

--- a/src/sidebar/panel.js
+++ b/src/sidebar/panel.js
@@ -3,6 +3,7 @@ const formats = [
   'bold',
   'font',
   'italic',
+  'underline',
   'size',
   'strike',
   'indent',
@@ -179,6 +180,7 @@ else
 const size = document.getElementsByClassName('ql-size')[0],
       bold = document.getElementsByClassName('ql-bold')[0],
       italic = document.getElementsByClassName('ql-italic')[0],
+      underline=document.getElementsByClassName('ql-underline')[0],
       strike = document.getElementsByClassName('ql-strike')[0],
       ordered = document.getElementsByClassName('ql-list')[0],
       bullet = document.getElementsByClassName('ql-list')[1];
@@ -187,6 +189,7 @@ const size = document.getElementsByClassName('ql-size')[0],
 size.title = browser.i18n.getMessage('fontSizeTitle');
 bold.title = browser.i18n.getMessage('boldTitle') + ' (' + userOSKey + '+B)';
 italic.title = browser.i18n.getMessage('italicTitle') + ' (' + userOSKey + '+I)';
+underline.title=browser.i18n.getMessage('underlineTitle')+'('+userOSKey+'+U)';
 strike.title = browser.i18n.getMessage('strikethroughTitle') + ' (' + userOSKey + '+Shift+' + bindings.strike.key + ')';
 ordered.title = browser.i18n.getMessage('numberedListTitle') + ' (' + userOSKey + '+Shift+' + bindings.ordered.key + ')';
 bullet.title = browser.i18n.getMessage('bulletedListTitle') + ' (' + userOSKey + '+Shift+' + bindings.bullet.key + ')';
@@ -353,8 +356,8 @@ function getPadStats() {
   const styles = {
     size: false,
     bold: false,
-
     italic: false,
+    underline:false,
     strike: false,
     list: false
   };
@@ -376,6 +379,7 @@ function getPadStats() {
     usesSize: styles.size,
     usesBold: styles.bold,
     usesItalics: styles.italic,
+    usesUnderline:styles.underline,
     usesStrikethrough: styles.strike,
     usesList: styles.list
   };


### PR DESCRIPTION
Add option to underline the text at the top panel.



After changes 
![underline](https://user-images.githubusercontent.com/26675957/31173308-aa3fb310-a924-11e7-8d64-64043172d415.png)
