### PR TITLE
Support for Links

### DIFF
--- a/src/sidebar/panel.js
+++ b/src/sidebar/panel.js
@@ -94,6 +94,7 @@ quill.on('text-change', function(delta) {
       endRetain += 1;
     }
     const text = quill.getText().substr(0, endRetain);
+    const format = quill.getFormat(text);
     const match = text.match(regex);
 
     if (match !== null) {
@@ -104,9 +105,16 @@ quill.on('text-change', function(delta) {
         ops.push({ retain: endRetain - url.length });
       }
 
+      const attributes = {};
+      // apply any previous formatting options to the attributes object
+      Object.keys(format).forEach(function(key) {
+        attributes[key] = format[key];
+      });
+      attributes['link'] = url;
+
       ops = ops.concat([
         { delete: url.length },
-        { insert: url, attributes: { link: url } }
+        { insert: url, attributes }
       ]);
 
       quill.updateContents({
@@ -165,6 +173,8 @@ quill.on('text-change', function(delta) {
     const format = quill.getFormat(delta.ops[0].retain, 1);
     if ('link' in format)
       quill.formatText(delta.ops[0].retain, 1, 'link', false);
+  } else if (delta.ops.length === 1 && delta.ops[0].hasOwnProperty('insert')) {
+    quill.formatText(0, 1, 'link', false);
   } else
     return;
 });


### PR DESCRIPTION
This initial commit fixes issues #253, #271, and #273. How these issues are fixed
is described below:

 - #253: When a space (or any character) is entered at index 0 of the editor
   with a link immediately following that character (as shown in the screen-grab
   for the issue), any formatting that is applied to the link will be applied
   to that character. The issue here was that the `link` format was being applied
   to space characters, but this is fixed by removing the `link` format from the
   first character of the editor.

 - #271 & #273: These issues involve the links getting any format they had
   applied to them removed as soon as the link-editing format was escaped. The
   fix for this was to capture and save the format of the link (formats like
   bold, italics, font size, etc.) then applying those same formats in addition
   to the `link` format when the url is turned into a link.