### PR TITLE
Bump version to 1.9.0dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notes",
   "id": "notes@mozilla.com",
   "description": "Displays a sidebar that lets you take notes on web pages.",
-  "version": "1.8.0dev",
+  "version": "1.9.0dev",
   "author": "Storage team",
   "bugs": {
     "url": "https://github.com/mozilla/notes/issues"

--- a/src/background.js
+++ b/src/background.js
@@ -10,7 +10,7 @@ const analytics = new TestPilotGA({
   ds: 'addon',
   an: 'Notes Experiment',
   aid: 'notes@mozilla.com',
-  av: '1.8.0dev'  // XXX: Change version on release
+  av: '1.9.0dev'  // XXX: Change version on release
 });
 
 function sendMetrics(event, context = {}) {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Firefox Notes",
   "description": "Displays a sidebar that lets you take notes on web pages.",
-  "version": "1.8.0dev",
+  "version": "1.9.0dev",
   "default_locale": "en_US",
   "author": "Mozilla Test Pilot team",
   "applications": {


### PR DESCRIPTION
To avoid Firefox's autoupdate to the Test Pilot version. Fixes confusions like in #332.