### PR TITLE
Dark Theme touchups

### DIFF
--- a/src/sidebar/styles-dark.css
+++ b/src/sidebar/styles-dark.css
@@ -80,12 +80,64 @@ body {
   background: #272B35;
 }
 
-#notes .ck-toolbar button:hover *,
 #notes .ck-toolbar button.ck-on *,
 #notes .ck-toolbar button:active * {
   color: #0080ff;
 }
 
+#notes .ck-button.ck-on {
+  background: #323744;
+}
+
+#notes .ck-toolbar .ck-button:focus:not(.ck-disabled),
+#notes .ck-toolbar .ck-button:hover:not(.ck-disabled),
+#notes .ck-toolbar a.ck-button:focus:not(.ck-disabled),
+#notes .ck-toolbar a.ck-button:hover:not(.ck-disabled) {
+  background: #323744;
+}
+
+#notes .ck-toolbar .ck-dropdown__button:hover:not(.ck-disabled) {
+  background: #323744;
+}
+
+#notes .ck-toolbar .ck-button__label {
+background: transparent;
+}
+
+#notes .ck-toolbar .ck-button .ck-icon, 
+#notes .ck-toolbar a.ck-button .ck-icon {
+  background: transparent;
+}
+
+#notes .ck-toolbar .ck-tooltip.ck-tooltip_s {
+  background: transparent;
+}
+
+#notes .ck-toolbar button .ck-tooltip__text {
+  border: solid thin #1c1f26;
+  color: #e6e6e6;
+}
+
+#notes .ck-toolbar .ck-tooltip.ck-tooltip_s .ck-tooltip__text::after {
+  border-color: transparent transparent #1c1f26;
+}
+
+#notes .ck-editor__main a {
+  color: #0080ff;
+}
+
+#notes .ck-toolbar .ck-list__item:hover {
+  background-color: #323744;
+}
+
+#notes .ck-toolbar .ck-list__item_active {
+  background-color: #0073e5;
+  color: #e6e6e6;
+}
+
+#notes .ck-toolbar .ck-list__item_active:hover {
+  background-color: #0080ff;
+}
 
 .ql-snow .ql-picker {
   color: #e6e6e6;

--- a/src/sidebar/styles.css
+++ b/src/sidebar/styles.css
@@ -204,6 +204,10 @@ CKEditor overrides
   width: 70px;
 }
 
+#notes .ck-button__label {
+  max-width: 30px;
+}
+
 .ck-balloon-panel {
   left: 0!important;
   width:100%!important;


### PR DESCRIPTION
**Changes made result in the following:**

 - fixed the heading dropdown border overlap issue

 - replicated `:hover` and `:active` styles from the light theme

 - added a border to tooltips to make them stand out better


**And a gif of the changes made (sorry for the poor quality):**

![dark_theme](https://user-images.githubusercontent.com/16343560/32977166-8bfc9e92-cbdc-11e7-8ade-1f03136d4564.gif)

