### PR TITLE
Add CODEOWNERS for l10n reviews

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# flod as main contact for string changes - TODO: find more to spread the effort
+locales/en-US/*.properties @flodolo


### PR DESCRIPTION
This should trigger a request review for any changes to the .properties file

In the past hours 10 strings landed without any review, and that's not optimal.