### PR TITLE
menu icon is now vertically centered

### DIFF
--- a/src/sidebar/styles.css
+++ b/src/sidebar/styles.css
@@ -322,7 +322,7 @@ footer {
   text-align: left;
   position: absolute;
   right: 6px;
-  top: 6px;
+  top: 5px;
   bottom: 6px;
 }
 


### PR DESCRIPTION
fixes: #527 
The changes made can be previewed below
![image](https://user-images.githubusercontent.com/30361728/34546643-2fe16336-f11b-11e7-9c87-4609e985d395.png)

I have highlighted the background of the menu icon to make the change prominent , as shown below
![screenshot from 2018-01-04 06-41-57](https://user-images.githubusercontent.com/30361728/34546692-71b0060a-f11b-11e7-8cd4-e395c5a96764.png)

  