### PR TITLE
The Firefox Notes feedback page is no longer wrongly opened on clicking the area around the 'notes' menu button

### DIFF
--- a/src/sidebar/panel.js
+++ b/src/sidebar/panel.js
@@ -213,6 +213,7 @@ function reconnectSync () {
 function disconnectFromSync () {
   waitingToReconnect = false;
   disconnectSync.style.display = 'none';
+  giveFeedbackButton.style.display = 'inherit';
   isAuthenticated = false;
   setAnimation(false, false, false); // animateSyncIcon, syncingLayout, warning
   setTimeout(() => {
@@ -235,12 +236,14 @@ function enableSyncAction(editor) {
 
   if (isAuthenticated && footerButtons.classList.contains('syncingLayout')) {
     // Trigger manual sync
+    giveFeedbackButton.style.display = 'none';
     setAnimation(true);
     browser.runtime.sendMessage({
         action: 'kinto-sync'
       });
   } else if (!isAuthenticated && (footerButtons.classList.contains('savingLayout') || waitingToReconnect)) {
     // Login
+    giveFeedbackButton.style.display = 'none';
     setAnimation(true, true, false);  // animateSyncIcon, syncingLayout, warning
 
     // enable disable sync button
@@ -272,6 +275,7 @@ function getLastSyncedTime() {
   }
 
   if (isAuthenticated) {
+    giveFeedbackButton.style.display = 'none';
     savingIndicator.textContent = browser.i18n.getMessage('syncComplete2', formatFooterTime(lastModified));
     disconnectSync.style.display = 'block';
     isAuthenticated = true;


### PR DESCRIPTION
fixes: #519 

I have fixed this but the only problem is that the size of the button background has been increased, **which can only be seen when we hover over the menu button**. Well according to me all things work fine, however if you don't prefer these changes then I will have to approach this some other way.

Here is a GIF of the changes
![simplescreenrecorder-2018-01-05_15 56 58](https://user-images.githubusercontent.com/30361728/34605516-eb5cebfa-f231-11e7-853f-139b835227e2.gif)

  