### PR TITLE
Add menu item to open notes in a tab rather than in the sidebar.

### DIFF
--- a/locales/en-US/notes.properties
+++ b/locales/en-US/notes.properties
@@ -54,3 +54,5 @@ textDirectionTitle=Text Direction
 themeLegend=Theme
 defaultThemeTitle=Default
 darkThemeTitle=Dark
+
+openInTab=Open in a tab

--- a/src/sidebar/panel.html
+++ b/src/sidebar/panel.html
@@ -47,6 +47,7 @@
         <button id="context-menu-button" class="mdl-js-button"></button>
         <ul class="mdl-menu mdl-menu--top-right mdl-js-menu context-menu" data-mdl-for="context-menu-button">
           <li id="disconnect-from-sync" class="mdl-menu__item context-menu-item"></li>
+          <li><a id="open-in-tab" class="mdl-menu__item context-menu-item"></a></li>
           <li><a id="give-feedback" class="mdl-menu__item context-menu-item"></a></li>
         </ul>
       </div>

--- a/src/sidebar/panel.js
+++ b/src/sidebar/panel.js
@@ -9,9 +9,10 @@ const footerButtons = document.getElementById('footer-buttons');
 const enableSync = document.getElementById('enable-sync');
 const giveFeedbackButton = document.getElementById('give-feedback-button');
 const giveFeedbackMenuItem = document.getElementById('give-feedback');
+const openInTabMenuItem = document.getElementById('open-in-tab');
 const savingIndicator = document.getElementById('saving-indicator');
 savingIndicator.textContent = browser.i18n.getMessage('changesSaved');
-
+openInTabMenuItem.textContent = browser.i18n.getMessage('openInTab');
 const disconnectSync = document.getElementById('disconnect-from-sync');
 disconnectSync.style.display = 'none';
 disconnectSync.textContent = browser.i18n.getMessage('disableSync');
@@ -29,6 +30,13 @@ giveFeedbackButton.setAttribute('title', browser.i18n.getMessage('feedback'));
 giveFeedbackMenuItem.text = browser.i18n.getMessage('feedback');
 giveFeedbackButton.setAttribute('href', SURVEY_PATH);
 giveFeedbackMenuItem.setAttribute('href', SURVEY_PATH);
+
+openInTabMenuItem.onclick = () => {
+  browser.tabs.create({
+    url: '/sidebar/panel.html',
+  });
+  browser.sidebarAction.close();
+};
 
 // ignoreNextLoadEvent is used to make sure the update does not trigger on other sidebars
 let ignoreNextLoadEvent = false;


### PR DESCRIPTION
Fixes #470 

The issue with this PR is that we only access the menu after logging in to sync...
Also we can still open in a new tab while being in a tab already.
  