### PR TITLE
Close all sidebars on toolbar button click.

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -192,7 +192,9 @@ browser.storage.local.get()
 // Handle onClick event for the toolbar button
 browser.browserAction.onClicked.addListener(() => {
   if (addonIsOpen) {
-    browser.sidebarAction.close();
+    browser.runtime.sendMessage('notes@mozilla.com', {
+      action: 'close'
+    });
   } else {
     browser.sidebarAction.open();
     setIconToActive();

--- a/src/sidebar/panel.js
+++ b/src/sidebar/panel.js
@@ -84,6 +84,9 @@ ClassicEditor.create(document.querySelector('#editor'), {
       chrome.runtime.onMessage.addListener(eventData => {
         let content;
         switch (eventData.action) {
+          case 'close':
+            browser.sidebarAction.close();
+            break;
           case 'sync-authenticated':
             setAnimation(true, true, false); // animateSyncIcon, syncingLayout, warning
             isAuthenticated = true;


### PR DESCRIPTION
Doesn't work because: sidebarAction.close may only be called from a user input handler

Attempt to fix #553