### PR TITLE
The previously used Sync email is wrongly displayed as a tooltip after logging out

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -119,9 +119,9 @@ browser.runtime.onMessage.addListener(function(eventData) {
       disconnectFromKinto(client).then(() => {
         sendMetrics('webext-button-disconnect', eventData.context);
         credentials.clear();
-      });
-      chrome.runtime.sendMessage({
-        action: 'disconnected'
+        chrome.runtime.sendMessage({
+          action: 'disconnected'
+        });
       });
       break;
     case 'kinto-load':

--- a/src/background.js
+++ b/src/background.js
@@ -120,6 +120,9 @@ browser.runtime.onMessage.addListener(function(eventData) {
         sendMetrics('webext-button-disconnect', eventData.context);
         credentials.clear();
       });
+      chrome.runtime.sendMessage({
+        action: 'disconnected'
+      });
       break;
     case 'kinto-load':
       retrieveNote(client).then((result) => {

--- a/src/sidebar/panel.js
+++ b/src/sidebar/panel.js
@@ -158,7 +158,7 @@ ClassicEditor.create(document.querySelector('#editor'), {
             break;
           case 'disconnected':
             disconnectSync.style.display = 'none';
-            footerButtons.title = null; // remove profile email from title attribute
+            footerButtons.removeAttribute('title');// remove profile email from title attribute
             isAuthenticated = false;
             setAnimation(false, false, false); // animateSyncIcon, syncingLayout, warning
             getLastSyncedTime();


### PR DESCRIPTION
fixes: #599 
GIF of changes is as follows
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/30361728/35344520-5bfedc94-0153-11e8-95de-c0574298d678.gif)
___________
@Natim , sorry for the delay