### PR TITLE
After logging off from "Firefox Notes", the "Give Feedback" button is now displayed in the other opened windows

### DIFF
--- a/src/sidebar/panel.js
+++ b/src/sidebar/panel.js
@@ -186,6 +186,7 @@ ClassicEditor.create(document.querySelector('#editor'), {
             syncingInProcess = false;
             break;
           case 'disconnected':
+            giveFeedbackButton.style.display = 'inherit';
             localStorage.removeItem('userEmail');
             disconnectSync.style.display = 'none';
             footerButtons.removeAttribute('title');// remove profile email from title attribute
@@ -257,7 +258,6 @@ function reconnectSync () {
 function disconnectFromSync () {
   waitingToReconnect = false;
   disconnectSync.style.display = 'none';
-  giveFeedbackButton.style.display = 'inherit';
   isAuthenticated = false;
   setAnimation(false, false, false); // animateSyncIcon, syncingLayout, warning
   setTimeout(() => {


### PR DESCRIPTION
fixes: #638 
This bug has occurred because of me. So I have fixed it
Please see the below GIF
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/30361728/35731621-5ade2398-083c-11e8-9361-bf7f9782ed18.gif)
