### PR TITLE
WIP: Export Notes content to file

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "sass-loader": "^6.0.6",
     "style-loader": "^0.19.0",
     "testpilot-ga": "^0.2.1",
+    "turndown": "^4.0.1",
     "webpack": "^3.8.1",
     "webpack-sources": "1.0.1"
   },

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -14,6 +14,8 @@ const files = [
   copySync('node_modules/material-design-lite/material.min.js', 'src/sidebar/vendor/material.js'),
   copySync('node_modules/material-design-lite/LICENSE', 'src/sidebar/vendor/material.LICENSE'),
   copySync('node_modules/@ckeditor/ckeditor5-build-classic/LICENSE.md', 'src/sidebar/vendor/ckeditor.LICENSE'),
+  copySync('node_modules/turndown/lib/turndown.umd.js', 'src/sidebar/vendor/turndown.js'),
+  copySync('node_modules/turndown/LICENSE', 'src/sidebar/vendor/turndown.LICENSE'),
   // Remove quill after migration
   copySync('node_modules/quill/LICENSE', 'src/sidebar/vendor/quill.LICENSE'),
   copySync('node_modules/quill/dist/quill.min.js', 'src/sidebar/vendor/quill.js')

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -40,6 +40,7 @@
     }]
   },
   "permissions": [
+    "downloads",
     "storage",
     "identity",
     "https://ssl.google-analytics.com/collect"

--- a/src/sidebar/panel.html
+++ b/src/sidebar/panel.html
@@ -46,6 +46,7 @@
       <div class="wrapper">
         <button id="context-menu-button" class="mdl-js-button"></button>
         <ul class="mdl-menu mdl-menu--top-right mdl-js-menu context-menu" data-mdl-for="context-menu-button">
+          <li><a id="export" class="mdl-menu__item context-menu-item"></a></li>
           <li id="disconnect-from-sync" class="mdl-menu__item context-menu-item"></li>
           <li><a id="give-feedback" class="mdl-menu__item context-menu-item"></a></li>
         </ul>

--- a/src/sidebar/panel.html
+++ b/src/sidebar/panel.html
@@ -46,7 +46,8 @@
       <div class="wrapper">
         <button id="context-menu-button" class="mdl-js-button"></button>
         <ul class="mdl-menu mdl-menu--top-right mdl-js-menu context-menu" data-mdl-for="context-menu-button">
-          <li><a id="export" class="mdl-menu__item context-menu-item"></a></li>
+          <li><a id="export_html" class="mdl-menu__item context-menu-item"></a></li>
+          <li><a id="export_markdown" class="mdl-menu__item context-menu-item"></a></li>
           <li id="disconnect-from-sync" class="mdl-menu__item context-menu-item"></li>
           <li><a id="give-feedback" class="mdl-menu__item context-menu-item"></a></li>
         </ul>
@@ -57,6 +58,7 @@
   <!-- Include the ckeditor library -->
   <script src="vendor/ckeditor.js"></script>
   <script src="vendor/quill.js"></script>
+  <script src="vendor/turndown.js"></script>
   <!-- Initialize ckeditor -->
   <script src="editor.js"></script>
   <script src="migration.js"></script>

--- a/src/sidebar/panel.js
+++ b/src/sidebar/panel.js
@@ -291,18 +291,21 @@ disconnectSync.addEventListener('click', disconnectFromSync);
 function exportNotes(editor, fileType) {
   let notesContent = null;
   let exportedFileName = null;
+  let exportFileType = null;
   switch (fileType) {
     case 'html':
       notesContent = editor.getData();
-      exportedFileName = 'notes_html.md';
+      exportedFileName = 'notes.html';
+      exportFileType = 'text/html';
       break;
     case 'markdown':
       notesContent = turndownService.turndown(editor.getData());
-      exportedFileName = 'notes_markdown.md';
+      exportedFileName = 'notes.md';
+      exportFileType = 'text/markdown';
       break;
   }
 
-  const data = new Blob([notesContent], {'type': 'text/markdown'});
+  const data = new Blob([notesContent], {'type': exportFileType});
   const exportFilePath = window.URL.createObjectURL(data);
   const downloading = browser.downloads.download({
     url: exportFilePath,

--- a/src/sidebar/panel.js
+++ b/src/sidebar/panel.js
@@ -12,6 +12,10 @@ const giveFeedbackMenuItem = document.getElementById('give-feedback');
 const savingIndicator = document.getElementById('saving-indicator');
 savingIndicator.textContent = browser.i18n.getMessage('changesSaved');
 
+let FILE_PATH = '';
+const exportButton = document.getElementById('export');
+exportButton.textContent = 'Export';
+
 const disconnectSync = document.getElementById('disconnect-from-sync');
 disconnectSync.style.display = 'none';
 disconnectSync.textContent = browser.i18n.getMessage('disableSync');
@@ -97,6 +101,14 @@ ClassicEditor.create(document.querySelector('#editor'), {
           ignoreNextLoadEvent = false;
         }
       });
+
+      exportButton.onclick = () => {
+          FILE_PATH = exportNotesContent(editor);
+          let downloading = browser.downloads.download({
+            url: FILE_PATH,
+            filename: 'notes.md'
+          });
+      };
 
       savingIndicator.onclick = () => {
         enableSyncAction(editor);
@@ -270,6 +282,13 @@ function disconnectFromSync() {
 }
 
 disconnectSync.addEventListener('click', disconnectFromSync);
+
+function exportNotesContent(editor) {
+  const notesContent = editor.getData();
+  const data = new Blob([notesContent], {'type': 'text/html'});
+  const file = window.URL.createObjectURL(data);
+  return file;
+}
 
 function enableSyncAction(editor) {
   if (editingInProcess || syncingInProcess) {


### PR DESCRIPTION
**Overview:**
This is a proof of concept attempt at implementing #189. A menu item has been added in the material design lite menu with a text context of "Export". When clicked, a file titled "notes.md" will be downloaded to the user's computer. The contents of "notes.md" is the contents of the Notes notepad, retrieved using the CKEditor5 `editor.getData()` method. This outputs the HTML of the editor contents - for example, 'Hello World' with no formatting would be `<p>Hello World</p>` in "notes.md".

**Example:**
![notes_export](https://user-images.githubusercontent.com/16343560/36081064-dc842d02-0f4e-11e8-9624-474d51e40924.gif)

Here is the Notes welcome message downloaded using the "Export" button: https://github.com/cedricium/test/blob/master/notes_html.md

Looking at the raw file, you'll see that it's just HTML: https://raw.githubusercontent.com/cedricium/test/master/notes_html.md

So any editor that allows GitHub-flavored Markdown (GFM) or more generally HTML-to-Markdown support should theoretically be able to view and edit this file.

**What's Next:**
- [x] Menu item "Export" --> "Export as..." with choice between HTML or Markdown
  - should be able to easily parse `editor.getData()`'s HTML output to Markdown using [Turndown](https://github.com/domchristie/turndown) or [Europa](https://github.com/NotNinja/europa) - 54c31ec 
- [ ] design proposal for Export UI from @ryanfeeley 
- [ ] localization of strings "Export as...", "HTML", "Markdown", etc.
- [ ] GA metrics
- [ ] Determine download's `conflictAction` value: "uniquify", "override", or "prompt"
  - maybe append Date/Time string to end of filename to make it unique?
