### PR TITLE
Disallow click event during syncing

### DIFF
--- a/src/sidebar/app/components/Footer.js
+++ b/src/sidebar/app/components/Footer.js
@@ -188,7 +188,7 @@ class Footer extends React.Component {
 
     this.enableSyncAction = () => {
       // persist reconnect warning, do not override with the 'saved at'
-      if (this.state.state.ignoreChange || !this.state.state.isClickable) return;
+      if (!this.state.state.isClickable) return;
 
       if (this.state.isAuthenticated) {
         // Trigger manual sync

--- a/src/sidebar/app/components/Footer.js
+++ b/src/sidebar/app/components/Footer.js
@@ -188,7 +188,7 @@ class Footer extends React.Component {
 
     this.enableSyncAction = () => {
       // persist reconnect warning, do not override with the 'saved at'
-      if (this.state.state.ignoreChange) return;
+      if (this.state.state.ignoreChange || !this.state.state.isClickable) return;
 
       if (this.state.isAuthenticated) {
         // Trigger manual sync


### PR DESCRIPTION
Simply add On click a check in current state if footer is clickable or not.
Fix #708