### PR TITLE
Disable 'Send to Notes' context menu item in Notes

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -215,7 +215,9 @@ browser.browserAction.onClicked.addListener(() => {
 browser.contextMenus.create({
   id: 'send-to-notes',
   title: browser.i18n.getMessage('sendToNotes'),
-  contexts: ['selection']
+  contexts: ['selection'],
+  // disables context menu item for Notes' `index.html` page
+  documentUrlPatterns: ['<all_urls>']
 });
 
 browser.contextMenus.onClicked.addListener((info) => {


### PR DESCRIPTION
This disables the context menu item 'Send to Notes' from being created / rendered in Notes itself. The `<all_urls>` document url patter does not match `resource://...` paths, which is what Notes' `index.html` falls under.

Fixes #710.