### PR TITLE
Allow Notes to be opened in New Tab

### DIFF
--- a/locales/en-US/notes.properties
+++ b/locales/en-US/notes.properties
@@ -108,6 +108,10 @@ themeLegend=Theme
 defaultThemeTitle=Default
 darkThemeTitle=Dark
 
+locationLegend=Open Notes in...
+defaultLocationLabel=Sidebar
+tabLocationLabel=New Tab
+
 # Displayed in the context menu when selecting text on a web page, used to send
 # the text to Firefox Notes. Keep "Notes" in English, since it's the name of the
 # add-on.

--- a/locales/en-US/notes.properties
+++ b/locales/en-US/notes.properties
@@ -108,7 +108,7 @@ themeLegend=Theme
 defaultThemeTitle=Default
 darkThemeTitle=Dark
 
-locationLegend=Open Notes in...
+locationLegend=Open Notes in
 defaultLocationLabel=Sidebar
 tabLocationLabel=New Tab
 

--- a/src/background.js
+++ b/src/background.js
@@ -205,14 +205,14 @@ const defaultNotesLocation = { location: 'sidebar' };
 browser.storage.local.get(['theme', 'location'])
   .then((storedSettings) => {
     // if no location or theme settings exists...
-    if (! storedSettings.location) {
+    if (!storedSettings.location) {
        // set defaultNotesLocation as initial location in local storage
       browser.storage.local.set(defaultNotesLocation);
       currentNotesLocation = defaultNotesLocation.location;
     } else {
       currentNotesLocation = storedSettings.location;
     }
-    if (! storedSettings.theme) {
+    if (!storedSettings.theme) {
        // set defaultTheme as initial theme in local storage
       browser.storage.local.set(defaultTheme);
     }
@@ -264,8 +264,8 @@ function sendSelectionText(selectionText) {
 
 function openNotesInTab() {
   // Check if there are any Notes tabs currently open...
-  const anyExistingNotesTabs = browser.tabs.query({ title: 'Firefox Notes' })
-    .then(notesTabs => {
+  const anyExistingNotesTabs = browser.tabs.query({ title: 'Firefox Notes' });
+  anyExistingNotesTabs.then(notesTabs => {
       // If no open Notes tabs, create a new Notes instance in a new tab
       if (notesTabs.length === 0) {
         // Close the Notes sidebar if open...

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -44,6 +44,7 @@
     "contextMenus",
     "storage",
     "identity",
+    "tabs",
     "https://ssl.google-analytics.com/collect"
   ],
   "background": {

--- a/src/settings/settings.css
+++ b/src/settings/settings.css
@@ -1,5 +1,5 @@
 body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto',
     'Helvetica Neue', Arial, sans-serif;
   color: #333;
 }
@@ -11,7 +11,11 @@ label {
   padding: 0;
 }
 
-label#themeTitle {
+label.sectionTitle {
   display: inline-block;
   width: 33%;
+}
+
+div.settingsSection {
+  margin-bottom: 8px;
 }

--- a/src/settings/settings.html
+++ b/src/settings/settings.html
@@ -19,7 +19,7 @@
         <label for="theme_dark" id="dark_label"></label>
       </div>
       <div class="settingsSection">
-        <label class="sectionTitle" id="notesLocationTitle">Open Notes in...</label>
+        <label class="sectionTitle" id="locationTitle">Open Notes in...</label>
 
         <input type="radio" name="location" value="sidebar" id="location_sidebar">
         <label for="location_sidebar" id="location_default_label">Sidebar</label>

--- a/src/settings/settings.html
+++ b/src/settings/settings.html
@@ -9,14 +9,23 @@
   <body>
 
     <div class="settings-content">
-      <div id="section-theme">
-        <label id="themeTitle"></label>
+      <div class="settingsSection" id="section-theme">
+        <label class="sectionTitle" id="themeTitle"></label>
 
         <input type="radio" name="theme" value="default" id="theme_default">
         <label for="theme_default" id="default_label"></label>
 
         <input type="radio" name="theme" value="dark" id="theme_dark">
         <label for="theme_dark" id="dark_label"></label>
+      </div>
+      <div class="settingsSection">
+        <label class="sectionTitle" id="notesLocationTitle">Open Notes in...</label>
+
+        <input type="radio" name="location" value="sidebar" id="location_sidebar">
+        <label for="location_sidebar" id="location_default_label">Sidebar</label>
+
+        <input type="radio" name="location" value="new_tab" id="location_tab">
+        <label for="location_tab" id="location_tab_label">New Tab</label>
       </div>
     </div>
 

--- a/src/settings/settings.js
+++ b/src/settings/settings.js
@@ -41,7 +41,7 @@ document.addEventListener('DOMContentLoaded', function() {
 function getSetting(settingOption) {
   let selectedSetting = {};
   switch (settingOption) {
-    case 'location':
+    case 'location': {
       let location = '';
       for (let i = 0; i < locationRadioBtn.length; i++) {
         if (locationRadioBtn[i].checked)
@@ -51,7 +51,8 @@ function getSetting(settingOption) {
       }
       selectedSetting = { location };
       break;
-    case 'theme':
+    }
+    case 'theme': {
       let theme = '';
       for (let i = 0; i < themeRadioBtn.length; i++) {
         if (themeRadioBtn[i].checked)
@@ -61,6 +62,7 @@ function getSetting(settingOption) {
       }
       selectedSetting = { theme };
       break;
+    }
   }
   return selectedSetting;
 }

--- a/src/settings/settings.js
+++ b/src/settings/settings.js
@@ -3,11 +3,17 @@ const themeLegend = document.getElementById('themeTitle');
 const defaultThemeLabel = document.getElementById('default_label');
 const darkThemeLabel = document.getElementById('dark_label');
 
-/* eslint-disable no-unsanitized/property */
-themeLegend.innerHTML = browser.i18n.getMessage('themeLegend');
-defaultThemeLabel.innerHTML = browser.i18n.getMessage('defaultThemeTitle');
-darkThemeLabel.innerHTML = browser.i18n.getMessage('darkThemeTitle');
-/* eslint-enable no-unsanitized/property */
+const locationLegend = document.getElementById('locationTitle');
+const defaultLocationLabel = document.getElementById('location_default_label');
+const tabLocationLabel = document.getElementById('location_tab_label');
+
+themeLegend.textContent = browser.i18n.getMessage('themeLegend');
+defaultThemeLabel.textContent = browser.i18n.getMessage('defaultThemeTitle');
+darkThemeLabel.textContent = browser.i18n.getMessage('darkThemeTitle');
+
+locationLegend.textContent = browser.i18n.getMessage('locationLegend');
+defaultLocationLabel.textContent = browser.i18n.getMessage('defaultLocationLabel');
+tabLocationLabel.textContent = browser.i18n.getMessage('tabLocationLabel');
 
 const themeRadioBtn = document.getElementsByName('theme');
 const locationRadioBtn = document.getElementsByName('location');

--- a/src/settings/settings.js
+++ b/src/settings/settings.js
@@ -10,41 +10,75 @@ darkThemeLabel.innerHTML = browser.i18n.getMessage('darkThemeTitle');
 /* eslint-enable no-unsanitized/property */
 
 const themeRadioBtn = document.getElementsByName('theme');
+const locationRadioBtn = document.getElementsByName('location');
 
 function loadSavedData(data) {
   const theme = data.theme;
+  const location = data.location;
 
-  if (theme === 'default') themeRadioBtn[0].checked = true;
-  else if (theme === 'dark') themeRadioBtn[1].checked = true;
+  if (theme === 'default')
+    themeRadioBtn[0].checked = true;
+  else if (theme === 'dark')
+    themeRadioBtn[1].checked = true;
+
+  if (location === 'sidebar')
+    locationRadioBtn[0].checked = true;
+  else if (location === 'new_tab')
+    locationRadioBtn[1].checked = true;
 }
 
 document.addEventListener('DOMContentLoaded', function() {
-  const savedData = browser.storage.local.get('theme');
+  const savedData = browser.storage.local.get(['theme', 'location']);
   savedData.then(loadSavedData);
 });
 
-function getTheme() {
-  let theme = '';
-
-  for (let i = 0; i < themeRadioBtn.length; i++) {
-    if (themeRadioBtn[i].checked) theme = themeRadioBtn[i].value;
-    else continue;
+function getSetting(settingOption) {
+  let selectedSetting = {};
+  switch (settingOption) {
+    case 'location':
+      let location = '';
+      for (let i = 0; i < locationRadioBtn.length; i++) {
+        if (locationRadioBtn[i].checked)
+          location = locationRadioBtn[i].value;
+        else
+          continue;
+      }
+      selectedSetting = { location };
+      break;
+    case 'theme':
+      let theme = '';
+      for (let i = 0; i < themeRadioBtn.length; i++) {
+        if (themeRadioBtn[i].checked)
+          theme = themeRadioBtn[i].value;
+        else
+          continue;
+      }
+      selectedSetting = { theme };
+      break;
   }
-
-  const selectedTheme = { theme };
-
-  return selectedTheme;
+  return selectedSetting;
 }
 
 for (let i = 0; i < themeRadioBtn.length; i++) {
   themeRadioBtn[i].onclick = function() {
-    const theme = getTheme();
-
+    const theme = getSetting('theme');
     browser.storage.local.set(theme);
-
     // notify background.js that theme settings have changed
     browser.runtime.sendMessage({
-      action: 'theme-changed'
+      action: 'theme-changed',
+      context: theme
+    });
+  };
+}
+
+for (let i = 0; i < locationRadioBtn.length; i++) {
+  locationRadioBtn[i].onclick = function() {
+    const location = getSetting('location');
+    browser.storage.local.set(location);
+    // notify background.js that location settings have changed
+    browser.runtime.sendMessage({
+      action: 'location-changed',
+      context: location
     });
   };
 }

--- a/src/sidebar/static/scss/footer.scss
+++ b/src/sidebar/static/scss/footer.scss
@@ -92,6 +92,7 @@ footer {
   top: 0px;
   bottom: 0px;
   width: 40px;
+  height: 40px;
   border-left: 1px solid #d7d7db;
   border-right: 1px solid #d7d7db;
   display: flex;

--- a/src/sidebar/static/scss/menu.scss
+++ b/src/sidebar/static/scss/menu.scss
@@ -80,6 +80,7 @@
 .mdl-menu__outline.mdl-menu--top-right {
   -webkit-transform-origin: 100% 100%;
   transform-origin: 100% 100%;
+  padding: 0 0 !important;
 }
 
 .mdl-menu {


### PR DESCRIPTION
## Description:

This fixes #470. Adds a new settings option, "Open Notes in..." which allows users to choose either to open Notes in the sidebar or in a new tab. The current implementation will open Notes in the tab when: 

1) the browser action button is pressed, or
2) the "Send to Notes" context menu option is selected.

Before opening a new Notes tab, all of the tabs open will be queried to see if a Notes tab exists - if so, then there will be no action, making sure there are no duplicate Notes tabs.

The **edge cases that will still open / show Notes in the sidebar** despite the "Open Notes in new tab" option being selected are **when the keyboard shortcut is used**, or when **Notes is manually selected from the dropdown menu in the sidebar.**

**cc:** @vladikoff @ryanfeeley let me know if this is what you had in mind.

## Picture + Demo: ✨ 

### Settings Page:
<div align="center">
  <img src="https://user-images.githubusercontent.com/16343560/36772885-e75bce64-1c0b-11e8-9d29-ff2e8986c91d.png">
</div>

### "Open Notes in New Tab" Demo:
<div align="center">
   <img src="https://user-images.githubusercontent.com/16343560/36773082-af0fc1ea-1c0c-11e8-9718-44243ed36b40.gif">
</div>
