### PR TITLE
Use Notes content to name "Export as" filenames

### DIFF
--- a/src/sidebar/app/components/Footer.js
+++ b/src/sidebar/app/components/Footer.js
@@ -162,7 +162,7 @@ class Footer extends React.Component {
       const parentElement = document.createElement('div');
       parentElement.innerHTML = notesContent; // eslint-disable-line no-unsanitized/property
 
-      let exportFileName =  'blank.html';
+      let exportFileName = 'blank.html';
       // get the first child element with text
       const nonEmptyChildElement = getFirstNonEmptyElement(parentElement);
 
@@ -221,7 +221,7 @@ class Footer extends React.Component {
         const that = this;
         this.loginTimeout = setTimeout(() => {
           that.setState({
-            state:  this.STATES.PLEASELOGIN
+            state: this.STATES.PLEASELOGIN
           });
         }, 5000);
 

--- a/src/sidebar/app/components/Footer.js
+++ b/src/sidebar/app/components/Footer.js
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 
 import SyncIcon from './SyncIcon';
 
-import { formatFooterTime } from '../utils/utils';
+import { formatFooterTime, getFirstNonEmptyElement } from '../utils/utils';
 import { SURVEY_PATH } from '../utils/constants';
 import INITIAL_CONTENT from '../data/initialContent';
 
@@ -156,10 +156,24 @@ class Footer extends React.Component {
     };
 
     this.exportAsHTML = () => {
+      // get Notes content
       const notesContent = this.state.content;
-      const exportedFileName = 'notes.html';
-      const exportFileType = 'text/html';
+      // assign contents to container element for later parsing
+      let parentElement = document.createElement('div');
+      parentElement.innerHTML = notesContent;
 
+      let exportedFileName =  '';
+      // get the first child element with text
+      let nonEmptyChildElement = getFirstNonEmptyElement(parentElement);
+
+      // if non-empty child element exists, set the filename to the element's `textContent`
+      if (nonEmptyChildElement) {
+        exportedFileName = `${nonEmptyChildElement.textContent.trim()}.html`;
+      } else { // if child elements are empty (aka empty notepad), set filename to 'blank.html'
+        exportedFileName = 'blank.html';
+      }
+
+      const exportFileType = 'text/html';
       const data = new Blob([`<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><title>Notes</title></head><body>${notesContent}</body></html>`], {'type': exportFileType});
       const exportFilePath = window.URL.createObjectURL(data);
       browser.downloads.download({

--- a/src/sidebar/app/components/Footer.js
+++ b/src/sidebar/app/components/Footer.js
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 
 import SyncIcon from './SyncIcon';
 
-import { formatFooterTime, getFirstNonEmptyElement } from '../utils/utils';
+import { formatFooterTime, getFirstNonEmptyElement, formatFilename } from '../utils/utils';
 import { SURVEY_PATH } from '../utils/constants';
 import INITIAL_CONTENT from '../data/initialContent';
 
@@ -159,18 +159,16 @@ class Footer extends React.Component {
       // get Notes content
       const notesContent = this.state.content;
       // assign contents to container element for later parsing
-      let parentElement = document.createElement('div');
-      parentElement.innerHTML = notesContent;
+      const parentElement = document.createElement('div');
+      parentElement.innerHTML = notesContent; // eslint-disable-line no-unsanitized/property
 
-      let exportedFileName =  '';
+      let exportFileName =  'blank.html';
       // get the first child element with text
-      let nonEmptyChildElement = getFirstNonEmptyElement(parentElement);
+      const nonEmptyChildElement = getFirstNonEmptyElement(parentElement);
 
       // if non-empty child element exists, set the filename to the element's `textContent`
       if (nonEmptyChildElement) {
-        exportedFileName = `${nonEmptyChildElement.textContent.trim()}.html`;
-      } else { // if child elements are empty (aka empty notepad), set filename to 'blank.html'
-        exportedFileName = 'blank.html';
+        exportFileName = formatFilename(nonEmptyChildElement.textContent);
       }
 
       const exportFileType = 'text/html';
@@ -178,7 +176,8 @@ class Footer extends React.Component {
       const exportFilePath = window.URL.createObjectURL(data);
       browser.downloads.download({
         url: exportFilePath,
-        filename: exportedFileName
+        filename: exportFileName,
+        saveAs: true // always open file chooser, fixes #733
       });
 
       chrome.runtime.sendMessage({

--- a/src/sidebar/app/utils/utils.js
+++ b/src/sidebar/app/utils/utils.js
@@ -12,19 +12,44 @@ function formatFooterTime(date) {
 }
 
 /**
- * 
- * @param {HTMLElement Object} parentElement 
+ *
+ * @param {HTMLElement Object} parentElement
  * @returns {HTMLElement Object}
  */
 function getFirstNonEmptyElement(parentElement) {
   // create an Array from parentElement's `children` (HTMLCollection)
-  const parentElementChildrenArray = Array.prototype.slice.call(parentElement.children);
+  let parentElementChildrenArray = [];
+  if (parentElement.children.length > 20) {
+    parentElementChildrenArray = Array.prototype.slice.call(parentElement.children[0, 20]);
+  } else {
+
+    parentElementChildrenArray = Array.prototype.slice.call(parentElement.children);
+  }
   // search for first child element that is not empty and return it
-  for (const [index, childElement] of parentElementChildrenArray.entries()) {
-    if (childElement.textContent.trim() !== '')
-      return childElement;
+  for (const childElement of parentElementChildrenArray.entries()) {
+    if (childElement[1].textContent.trim() !== '')
+      return childElement[1];
   }
   return false; // all children empty, so return false
 }
 
-export { formatFooterTime, getFirstNonEmptyElement };
+/**
+ * Formats the filename for the "Export as HTML..." menu option.
+ * Whitespace and illegal filename characters are removed, and
+ * the length is shortened if longer than 250 characters.
+ * @param {string} filename
+ * @returns {string}
+ */
+function formatFilename(filename) {
+  let formattedFilename = filename;
+  // remove surrounding whitespace
+  formattedFilename = formattedFilename.trim();
+  // remove illegal filename characters
+  formattedFilename = formattedFilename.replace(/[~#%{}[\]:\\<>/!@&?"*.+|\n\r\t]/g, '');
+  if (formattedFilename.length > 250) { // 255 bytes (filesystem max) - 4 for ".html" extension
+    formattedFilename = formattedFilename.substring(0, 250);
+  }
+  return formattedFilename;
+}
+
+export { formatFooterTime, getFirstNonEmptyElement, formatFilename };

--- a/src/sidebar/app/utils/utils.js
+++ b/src/sidebar/app/utils/utils.js
@@ -17,20 +17,15 @@ function formatFooterTime(date) {
  * @returns {HTMLElement Object}
  */
 function getFirstNonEmptyElement(parentElement) {
-  // create an Array from parentElement's `children` (HTMLCollection)
-  let parentElementChildrenArray = [];
-  if (parentElement.children.length > 20) {
-    parentElementChildrenArray = Array.prototype.slice.call(parentElement.children[0, 20]);
-  } else {
-
-    parentElementChildrenArray = Array.prototype.slice.call(parentElement.children);
-  }
+  // create an Array from parentElement's `children` (limited to 20 child elements)
+  const parentElementChildrenArray = Array.prototype.filter.call(parentElement.children, (el, index) => {
+    return el && index < 20;
+  });
   // search for first child element that is not empty and return it
-  for (const childElement of parentElementChildrenArray.entries()) {
-    if (childElement[1].textContent.trim() !== '')
-      return childElement[1];
-  }
-  return false; // all children empty, so return false
+  const nonEmptyChild = parentElementChildrenArray.find(el => {
+    return el.textContent.trim() !== '';
+  });
+  return nonEmptyChild;
 }
 
 /**
@@ -46,10 +41,10 @@ function formatFilename(filename) {
   formattedFilename = formattedFilename.trim();
   // remove illegal filename characters
   formattedFilename = formattedFilename.replace(/[~#%{}[\]:\\<>/!@&?"*.+|\n\r\t]/g, '');
-  if (formattedFilename.length > 250) { // 255 bytes (filesystem max) - 4 for ".html" extension
+  if (formattedFilename.length > 250) { // 255 bytes (filesystem max) - 5 for ".html" extension
     formattedFilename = formattedFilename.substring(0, 250);
   }
-  return formattedFilename;
+  return `${formattedFilename}.html`;
 }
 
 export { formatFooterTime, getFirstNonEmptyElement, formatFilename };

--- a/src/sidebar/app/utils/utils.js
+++ b/src/sidebar/app/utils/utils.js
@@ -11,4 +11,20 @@ function formatFooterTime(date) {
   });
 }
 
-export { formatFooterTime };
+/**
+ * 
+ * @param {HTMLElement Object} parentElement 
+ * @returns {HTMLElement Object}
+ */
+function getFirstNonEmptyElement(parentElement) {
+  // create an Array from parentElement's `children` (HTMLCollection)
+  const parentElementChildrenArray = Array.prototype.slice.call(parentElement.children);
+  // search for first child element that is not empty and return it
+  for (const [index, childElement] of parentElementChildrenArray.entries()) {
+    if (childElement.textContent.trim() !== '')
+      return childElement;
+  }
+  return false; // all children empty, so return false
+}
+
+export { formatFooterTime, getFirstNonEmptyElement };


### PR DESCRIPTION
Fixes https://github.com/mozilla/notes/issues/733
Fixes https://github.com/mozilla/notes/issues/735

Eventual fix for #735.

@vladikoff mind going over what I have so far? I feel as if I'm over-complicating things, but at the same time I feel like there's a lot needed to get the correct filename.

Per @ryanfeeley:

> OK, I spoke with the higher powers. We should follow was Firefox does when you Save Page As… and just use the title of the note.
> e.g Mattress Shopping.html no time stamp
> If the note is blank use: blank.html or better, disable the export note option in that state.

and 

> Yes, the first line that has text, it should use the text from that line to a maximum of 255 characters and just end it, no ellipsis.

My thought process was then:

1. **Notes not empty:** Notes has text in the notepad. Said text could possibly be halfway down the page meaning there are multiple empty `<p>` elements before the text:

```html
<p></p>
<p></p>
<p></p>
<p>Some text</p>

<!-- filename = "Some text.html" -->
```
This means we need to find the first element that contains text in order to set it as the filename. This first commit does just this. Still need to only get the first sentence or ensure the text is no longer than 255 characters.

2. **Notes empty:** If Notes is empty, then we could just set the title of the filename to "blank.html" (currently implemented). If we did want to go the "disable the context menu option if Notes empty", I might advise against it. It would be taxing to constantly check if Notes is empty and Google allows for downloading documents without a title.