### PR TITLE
Fix text ellipsis too far from menu

### DIFF
--- a/src/sidebar/static/scss/footer.scss
+++ b/src/sidebar/static/scss/footer.scss
@@ -148,7 +148,7 @@ footer {
 }
 
 #syncing-indicator {
-  width: calc(100% - 10px);
+  width: calc(100% - 6px);
   text-overflow: ellipsis;
   overflow: hidden;
   margin-top: 1px;

--- a/src/sidebar/static/scss/footer.scss
+++ b/src/sidebar/static/scss/footer.scss
@@ -34,7 +34,7 @@ footer {
   div:first-child {
     position: relative;
     flex: 1 0;
-    padding: 10px 40px 10px 10px;
+    padding: 10px 10px 10px 10px;
     color: #969696;
     text-align: left;
     display: block;
@@ -148,7 +148,7 @@ footer {
 }
 
 #syncing-indicator {
-  width: calc(100% - 25px);
+  width: calc(100% - 10px);
   text-overflow: ellipsis;
   overflow: hidden;
   margin-top: 1px;


### PR DESCRIPTION
Ellipsis are not properly done in latest menu version. This PR fix it.

**Before**:
<img width="245" alt="capture d ecran 2018-03-09 a 08 39 24" src="https://user-images.githubusercontent.com/3018618/37196076-aba1e5b8-2375-11e8-87ad-00e4a1b27555.png">
<img width="260" alt="capture d ecran 2018-03-09 a 08 39 37" src="https://user-images.githubusercontent.com/3018618/37196077-abb73f6c-2375-11e8-98a1-bb236b7eace8.png">

**After**:
<img width="257" alt="capture d ecran 2018-03-09 a 08 39 52" src="https://user-images.githubusercontent.com/3018618/37196083-afb5c9ee-2375-11e8-8083-cfea435acb06.png">
<img width="309" alt="capture d ecran 2018-03-09 a 08 43 19" src="https://user-images.githubusercontent.com/3018618/37196147-f8dafd60-2375-11e8-89f6-0e5882b18eb6.png">


 