### PR TITLE
Blur context menu button when menu closes

### DIFF
--- a/src/sidebar/app/components/Footer.js
+++ b/src/sidebar/app/components/Footer.js
@@ -157,6 +157,8 @@ class Footer extends React.Component {
     this.onCloseListener = () => {
       this.menu.classList.replace('open', 'close');
       window.removeEventListener('keydown', this.handleKeyPress);
+      // Blur `this.contextMenuBtn` when context menu closes - fixes #770
+      this.contextMenuBtn.blur();
     };
 
     // Open and close menu
@@ -354,6 +356,7 @@ class Footer extends React.Component {
 
           <div className="photon-menu close top left" ref={menu => this.menu = menu }>
             <button
+              ref={contextMenuBtn => this.contextMenuBtn = contextMenuBtn}
               id="context-menu-button"
               onClick={(e) => this.toggleMenu(e)}
               onKeyDown={this.handleKeyPress}>


### PR DESCRIPTION
Fixes #770 

Tested on Windows and works. Don't have a Linux machine so if someone else could verify that'd be great.