### PR TITLE
Send to Note + Multi-Note + Multi-Window

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -239,24 +239,26 @@ browser.contextMenus.create({
   documentUrlPatterns: ['<all_urls>']
 });
 
-browser.contextMenus.onClicked.addListener((info) => {
+browser.contextMenus.onClicked.addListener((info, tab) => {
   // open sidebar which will trigger `isEditorReady`...
   browser.sidebarAction.open();
   // then send selection text to Editor.js once editor instance is initialized and ready
-  sendSelectionText(info.selectionText);
+  sendSelectionText(info.selectionText, tab.windowId);
 });
 
-function sendSelectionText(selectionText) {
+// We receive this ... GREAT
+function sendSelectionText(selectionText, windowId) {
   // if editor ready, go ahead and send selected text to be pasted in Notes,
   // otherwise wait half a second before trying again
   if (isEditorReady) {
     chrome.runtime.sendMessage({
       action: 'send-to-notes',
+      windowId,
       text: selectionText
     });
   } else {
     setTimeout(() => {
-      sendSelectionText(selectionText);
+      sendSelectionText(selectionText, windowId);
     }, 500);
   }
 }

--- a/src/sidebar/app/onMessage.js
+++ b/src/sidebar/app/onMessage.js
@@ -19,6 +19,7 @@ import store from './store';
  * Share state between instances ... update-redux?
  * No idea if this is a good idea or not.
  */
+
 chrome.runtime.onMessage.addListener(eventData => {
     switch (eventData.action) {
       //
@@ -60,13 +61,21 @@ chrome.runtime.onMessage.addListener(eventData => {
         }
         break;
       case SEND_TO_NOTES: {
-          const focusedNoteId = store.getState().sync.focusedNoteId;
-          if (focusedNoteId) {
-            store.dispatch(sendToNote(focusedNoteId, eventData.text));
-          } else {
-            store.dispatch(createNote(`<p>${ eventData.text }</p>`));
+        browser.windows.getCurrent({populate: true}).then((windowInfo) => {
+          if (windowInfo.id === eventData.windowId) {
+            const focusedNoteId = store.getState().sync.focusedNoteId;
+            if (focusedNoteId) {
+              store.dispatch(sendToNote(focusedNoteId, eventData.text));
+            } else {
+              store.dispatch(createNote(`<p>${ eventData.text }</p>`));
+            }
+            browser.runtime.sendMessage({
+              action: 'kinto-sync'
+            });
           }
-        }
+        });
         break;
+      }
     }
 });
+


### PR DESCRIPTION
On send-to-note, we propagate windowId from background to react app which perform the action only if nto from an other window.
Have to be performed in sidebar react app since background do not know which note is displayed.

Fix #787