### PR TITLE
Handle sync errors

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -69,7 +69,6 @@ An event fired when the user completes a change of the content of the notepad. I
 - `cd6`
 
 #### `drag-n-drop`
-
 An event fired when the user tries to drag or drop a content into the notepad.
 
 - `ec` - `notes`
@@ -142,7 +141,6 @@ An event fired when the "Send to Notes" context menu is used
 - `ea` - `metrics-context-menu`
 
 #### `limit-reached`
-
 An event fired when user goes over the pad limit (15000 character)
 
 - `ec` - `notes`
@@ -157,15 +155,15 @@ An event fired when user goes over the pad limit (15000 character)
 - `cd6`
 
 #### `idb-fail`
-
 An event fired when IndexedDB fails to load
 
 - `ec` - `notes`
 - `ea` - `idb-fail`
 
-
-#### `migrate-single-note`
-An event fired when migrating singleNote to multiNote
+### `delete-deleted-notes`
+A client retrieved notes which have been deleted on client side but not proparly
+deleted on server side. Those were deleted before v4.0.0-beta.4 (during multi-note implementation).
 
 - `ec` - `notes`
-- `ea` - `migrate-single-note`
+- `ea` - `delete-deleted-notes`
+

--- a/locales/en-US/notes.properties
+++ b/locales/en-US/notes.properties
@@ -122,3 +122,4 @@ backToAllNotes=Back to all notes
 newNote=New Note
 makePlainText=Make Plain Text
 deleteNote=Delete Note
+insufficientStorage=Insufficient Storage

--- a/src/sidebar/app/actions.js
+++ b/src/sidebar/app/actions.js
@@ -11,6 +11,7 @@ import { SYNC_AUTHENTICATED,
          PLEASE_LOGIN,
          OPENING_LOGIN,
          FOCUS_NOTE,
+         ERROR,
          REQUEST_WELCOME_PAGE } from './utils/constants';
 
 import INITIAL_CONTENT from './data/initialContent';
@@ -168,4 +169,8 @@ export function setFocusedNote(id) {
 
 export function requestWelcomeNote() {
   return { type: REQUEST_WELCOME_PAGE };
+}
+
+export function error(message) {
+  return { type: ERROR, message};
 }

--- a/src/sidebar/app/components/Footer.js
+++ b/src/sidebar/app/components/Footer.js
@@ -39,6 +39,10 @@ class Footer extends React.Component {
         isReconnectState: true,
         text: () => browser.i18n.getMessage('reconnectSync')
       },
+      ERROR: {
+        yellowBackground: true,
+        isClickable: true
+      },
       SYNCING: {
         animateSyncIcon: true,
         text: () => browser.i18n.getMessage('syncProgress')
@@ -52,7 +56,10 @@ class Footer extends React.Component {
     this.getFooterState = (state) => {
       let res;
       if (state.sync.email) { // If user is authenticated
-        if (state.sync.isSyncing) {
+        if (state.sync.error) {
+          res = this.STATES.ERROR;
+          res.text = () => state.sync.error;
+        } else if (state.sync.isSyncing) {
           res = this.STATES.SYNCING;
         } else {
           res = this.STATES.SYNCED;

--- a/src/sidebar/app/components/Footer.js
+++ b/src/sidebar/app/components/Footer.js
@@ -41,7 +41,7 @@ class Footer extends React.Component {
       },
       ERROR: {
         yellowBackground: true,
-        isClickable: true
+        isClickable: false
       },
       SYNCING: {
         animateSyncIcon: true,

--- a/src/sidebar/app/onMessage.js
+++ b/src/sidebar/app/onMessage.js
@@ -4,6 +4,7 @@ import { SYNC_AUTHENTICATED,
          TEXT_SYNCED,
          RECONNECT_SYNC,
          DISCONNECTED,
+         ERROR,
          SEND_TO_NOTES } from './utils/constants';
          // Actions
 import { authenticate,
@@ -12,7 +13,8 @@ import { authenticate,
          synced,
          reconnectSync,
          sendToNote,
-         kintoLoad } from './actions';
+         kintoLoad,
+         error } from './actions';
 import store from './store';
 /**
  * For each event, action on redux to update UI. No longer any event from chrome in components
@@ -55,6 +57,9 @@ chrome.runtime.onMessage.addListener(eventData => {
         break;
       case RECONNECT_SYNC:
         store.dispatch(reconnectSync());
+        break;
+      case ERROR:
+        store.dispatch(error(eventData.message));
         break;
       case DISCONNECTED:
         if (store.getState().sync.email) {

--- a/src/sidebar/app/reducers.js
+++ b/src/sidebar/app/reducers.js
@@ -12,6 +12,7 @@ import {
   PLEASE_LOGIN,
   FOCUS_NOTE,
   SEND_TO_NOTES,
+  ERROR,
   REQUEST_WELCOME_PAGE
 } from './utils/constants';
 
@@ -26,7 +27,8 @@ function sync(sync = {}, action) {
         isReconnectSync: false,
         email: action.email,
         lastSynced: new Date(),
-        isSyncing: true
+        isSyncing: true,
+        error: null
       });
     case DISCONNECTED:
       return Object.assign({}, sync, {
@@ -34,6 +36,7 @@ function sync(sync = {}, action) {
         isOpeningLogin: false,
         isPleaseLogin: false,
         isReconnectSync: false,
+        error: null
       });
     case OPENING_LOGIN:
       return Object.assign({}, sync, {
@@ -46,6 +49,7 @@ function sync(sync = {}, action) {
         isOpeningLogin: false,
         isPleaseLogin: true,
         isReconnectSync: false,
+        error: null
       });
     case RECONNECT_SYNC:
       return Object.assign({}, sync, {
@@ -53,14 +57,17 @@ function sync(sync = {}, action) {
         isOpeningLogin: false,
         isPleaseLogin: false,
         isReconnectSync: true,
+        error: null
       });
     case DELETE_NOTE:
       return Object.assign({}, sync, {
-        isSyncing: true
+        isSyncing: true,
+        error: null
       });
     case UPDATE_NOTE:
       return Object.assign({}, sync, {
-        isSyncing: true
+        isSyncing: true,
+        error: null
       });
     case TEXT_SYNCED:
       return Object.assign({}, sync, {
@@ -84,6 +91,10 @@ function sync(sync = {}, action) {
     case CREATE_NOTE:
       return Object.assign({}, sync, {
         welcomePage: false
+      });
+    case ERROR:
+      return Object.assign({}, sync, {
+        error: action.message
       });
     default:
       return sync;

--- a/src/sidebar/app/reducers.js
+++ b/src/sidebar/app/reducers.js
@@ -49,6 +49,7 @@ function sync(sync = {}, action) {
       });
     case RECONNECT_SYNC:
       return Object.assign({}, sync, {
+        email: null,
         isOpeningLogin: false,
         isPleaseLogin: false,
         isReconnectSync: true,

--- a/src/sidebar/app/utils/constants.js
+++ b/src/sidebar/app/utils/constants.js
@@ -19,4 +19,5 @@ export const UPDATE_NOTE = 'text-change';
 export const DELETE_NOTE = 'delete-note';
 
 export const FOCUS_NOTE = 'focus-note';
+export const ERROR = 'error';
 export const REQUEST_WELCOME_PAGE = 'request-welcome-page';

--- a/src/sync.js
+++ b/src/sync.js
@@ -272,7 +272,7 @@ function syncKinto(client, credentials) {
         // cannot refresh the access token, log the user out.
         browser.runtime.sendMessage('notes@mozilla.com', {
           action: 'error',
-          message: 'Insufficient Storage',
+          message: browser.i18n.getMessage('insufficientStorage')
         });
         return Promise.reject(error);
       }

--- a/src/sync.js
+++ b/src/sync.js
@@ -104,9 +104,9 @@ class JWETransformer {
       decoded.deleted = true;
       // On decode, we flag notes with _status deleted but still on server.
       // We automatically will request deletion for those.
-      // (This is due to singleNote overriding deleted state with udpated to server)
-      // Should be deleted when every user who tryed beta runned it once.
-      // (see meetrics deleteDeleted)
+      // (This is due to singleNote replacing 'deleted' state by 'updated')
+      // Should be deleted when every user who tried beta runned it once.
+      // (see metrics deleteDeleted)
       deletedNotesStillOnServer[decoded.id] = decoded;
     }
     return decoded;


### PR DESCRIPTION
After authenticating, kinto might return some errors we should handle.

- [x] fix synced UI after kinto error. Should request reconnect.
- [x] implement a solution to unblock the user.
- [x] display used quota. #837
- [ ] display an error message to inform the user.

Fix #791 #801 #802 #827