### PR TITLE
Add CD10 to all metrics

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -35,6 +35,8 @@ Data will be collected with Google Analytics and follow [Test Pilot standards](h
 - `cd7` - the UI element used to open or close the notepad. Possible values TBD, but may include `closeButton`, `sidebarButton`, and `sidebarSwitcher`.
 - `cd8` - the reason an editing session ended. One of `timeout` or `closed`.
 - `cd9` - whether the user was able to load the note panel or not. One of `true` or `false`.
+- `cd10` - provide current user state. Possible values are: 'error', 'isSyncing', 'synced', 'openLogin', 'verifyAccount', 'reconnectSync', and 'signIn'.
+
 
 ### Events
 
@@ -44,6 +46,7 @@ An event fired when the user actively navigates to the Notes sidebar. Includes:
 - `ec` - `notes`
 - `ea` - `open`
 - `cd9`
+- `cd10`
 
 #### `close`
 An event fired when the user actively navigates away from the Notes sidebar. Includes:
@@ -52,6 +55,7 @@ An event fired when the user actively navigates away from the Notes sidebar. Inc
 - `ea` - `close`
 - `cd7`
 - `cd8`
+- `cd10`
 
 #### `changed`
 An event fired when the user completes a change of the content of the notepad. It prospectively begins when a user focuses on the notepad's editable area, and ends when the user either 1) closes the sidebar, or 2) does not make any changes in 20 seconds. Includes:
@@ -67,6 +71,7 @@ An event fired when the user completes a change of the content of the notepad. I
 - `cd4`
 - `cd5`
 - `cd6`
+- `cd10`
 
 #### `drag-n-drop`
 An event fired when the user tries to drag or drop a content into the notepad.
@@ -82,6 +87,7 @@ An event fired when the user tries to drag or drop a content into the notepad.
 - `cd4`
 - `cd5`
 - `cd6`
+- `cd10`
 
 #### `sync-started` (deprecated)
 
@@ -91,54 +97,63 @@ An event fired whenever the user attempts to login to sync. Includes:
 
 - `ec` - `notes`
 - `ea` - `sync-started`
+- `cd10`
 
 #### `login-success`
 An event fired whenever the user enables sync successfully. Includes:
 
 - `ec` - `notes`
 - `ea` - `login-success`
+- `cd10`
 
 #### `login-failed`
 An event fired whenever the user enables sync but the FxA login fails. Includes:
 
 - `ec` - `notes`
 - `ea` - `login-failed`
+- `cd10`
 
 #### `theme-changed`
 An event fired whenever the user changes the theme. Includes:
 
 - `ec` - `notes`
 - `ea` - `theme-changed`
+- `cd10`
 
 #### `webext-button-authenticate`
 An event fired when user presses the sync button
 
 - `ec` - `notes`
 - `ea` - `webext-button-authenticate`
+- `cd10`
 
 #### `webext-button-disconnect`
 An event fired when user logs out of sync
 
 - `ec` - `notes`
 - `ea` - `webext-button-disconnect`
+- `cd10`
 
 #### `handle-conflict`
 An event fired when sync resolved a sync conflict
 
 - `ec` - `notes`
 - `ea` - `handle-conflict`
+- `cd10`
 
 #### `reconnect-sync`
 An event fired when user closes sync due to a password reset or change
 
 - `ec` - `notes`
 - `ea` - `reconnect-sync`
+- `cd10`
 
 #### `context-menu`
 An event fired when the "Send to Notes" context menu is used
 
 - `ec` - `notes`
 - `ea` - `metrics-context-menu`
+- `cd10`
 
 #### `limit-reached`
 An event fired when user goes over the pad limit (15000 character)
@@ -153,12 +168,14 @@ An event fired when user goes over the pad limit (15000 character)
 - `cd4`
 - `cd5`
 - `cd6`
+- `cd10`
 
 #### `idb-fail`
 An event fired when IndexedDB fails to load
 
 - `ec` - `notes`
 - `ea` - `idb-fail`
+- `cd10`
 
 ### `delete-deleted-notes`
 A client retrieved notes which have been deleted on client side but not proparly
@@ -166,4 +183,5 @@ deleted on server side. Those were deleted before v4.0.0-beta.4 (during multi-no
 
 - `ec` - `notes`
 - `ea` - `delete-deleted-notes`
+- `cd10`
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -97,63 +97,54 @@ An event fired whenever the user attempts to login to sync. Includes:
 
 - `ec` - `notes`
 - `ea` - `sync-started`
-- `cd10`
 
 #### `login-success`
 An event fired whenever the user enables sync successfully. Includes:
 
 - `ec` - `notes`
 - `ea` - `login-success`
-- `cd10`
 
 #### `login-failed`
 An event fired whenever the user enables sync but the FxA login fails. Includes:
 
 - `ec` - `notes`
 - `ea` - `login-failed`
-- `cd10`
 
 #### `theme-changed`
 An event fired whenever the user changes the theme. Includes:
 
 - `ec` - `notes`
 - `ea` - `theme-changed`
-- `cd10`
 
 #### `webext-button-authenticate`
 An event fired when user presses the sync button
 
 - `ec` - `notes`
 - `ea` - `webext-button-authenticate`
-- `cd10`
 
 #### `webext-button-disconnect`
 An event fired when user logs out of sync
 
 - `ec` - `notes`
 - `ea` - `webext-button-disconnect`
-- `cd10`
 
 #### `handle-conflict`
 An event fired when sync resolved a sync conflict
 
 - `ec` - `notes`
 - `ea` - `handle-conflict`
-- `cd10`
 
 #### `reconnect-sync`
 An event fired when user closes sync due to a password reset or change
 
 - `ec` - `notes`
 - `ea` - `reconnect-sync`
-- `cd10`
 
 #### `context-menu`
 An event fired when the "Send to Notes" context menu is used
 
 - `ec` - `notes`
 - `ea` - `metrics-context-menu`
-- `cd10`
 
 #### `limit-reached`
 An event fired when user goes over the pad limit (15000 character)
@@ -175,7 +166,6 @@ An event fired when IndexedDB fails to load
 
 - `ec` - `notes`
 - `ea` - `idb-fail`
-- `cd10`
 
 ### `delete-deleted-notes`
 A client retrieved notes which have been deleted on client side but not proparly
@@ -183,5 +173,4 @@ deleted on server side. Those were deleted before v4.0.0-beta.4 (during multi-no
 
 - `ec` - `notes`
 - `ea` - `delete-deleted-notes`
-- `cd10`
 

--- a/src/background.js
+++ b/src/background.js
@@ -27,8 +27,8 @@ const analytics = new TestPilotGA({
   av: browser.runtime.getManifest().version
 });
 
-// This object is updated onMessage 'redux', sended by sidebar store.js on evry change.
-// We need to keep it to generate cd10
+// This object is updated onMessage 'redux', sended by sidebar store.js on every change.
+// We need to keep it to generate `cd10`
 let reduxSync = {};
 
 function sendMetrics(event, context = {}, sync = reduxSync) {

--- a/src/background.js
+++ b/src/background.js
@@ -82,7 +82,7 @@ function sendMetrics(event, context = {}, sync = reduxSync) {
     return analytics.sendEvent('notes', event, metrics);
   };
   clearTimeout(timeouts[event]);
-  timeouts[event] = setTimeout(later, 4000);
+  timeouts[event] = setTimeout(later, 20000);
 }
 
 function authenticate() {

--- a/src/background.js
+++ b/src/background.js
@@ -19,7 +19,6 @@ let isEditorReady = false;
 const client = new Kinto({remote: KINTO_SERVER, bucket: 'default'});
 
 // Analytics
-
 const analytics = new TestPilotGA({
   tid: TRACKING_ID,
   ds: 'addon',
@@ -28,7 +27,12 @@ const analytics = new TestPilotGA({
   av: browser.runtime.getManifest().version
 });
 
-function sendMetrics(event, context = {}) {
+// This object is updated onMessage 'redux', sended by sidebar store.js on evry change.
+// We need to keep it to generate cd10
+let reduxSync = {};
+
+function sendMetrics(event, context = {}, sync = reduxSync) {
+
   // This function debounce sending metrics.
   const later = function() {
     timeouts[event] = null;
@@ -54,10 +58,31 @@ function sendMetrics(event, context = {}) {
       };
     }
 
+    // Generate cd10 based on footer.js rules
+    if (sync.email) { // If user is authenticated
+      if (sync.error) {
+        metrics.cd10 = 'error';
+      } else if (sync.isSyncing) {
+        metrics.cd10 = 'isSyncing';
+      } else {
+        metrics.cd10 = 'synced';
+      }
+    } else {
+      if (sync.isOpeningLogin) { // eslint-disable-line no-lonely-if
+        metrics.cd10 = 'openLogin';
+      } else if (sync.isPleaseLogin) {
+        metrics.cd10 = 'verifyAccount';
+      } else if (sync.isReconnectSync) {
+        metrics.cd10 = 'reconnectSync';
+      } else {
+        metrics.cd10 = 'signIn';
+      }
+    }
+
     return analytics.sendEvent('notes', event, metrics);
   };
   clearTimeout(timeouts[event]);
-  timeouts[event] = setTimeout(later, 20000);
+  timeouts[event] = setTimeout(later, 4000);
 }
 
 function authenticate() {
@@ -189,6 +214,9 @@ browser.runtime.onMessage.addListener(function(eventData) {
       browser.runtime.sendMessage({
         action: 'theme-changed'
       });
+      break;
+    case 'redux':
+      reduxSync = eventData.sync;
       break;
   }
 });

--- a/src/sidebar/app/store.js
+++ b/src/sidebar/app/store.js
@@ -11,6 +11,13 @@ const storeState = store => next => action => {
   browser.storage.local.set({
     redux: JSON.stringify(store.getState())
   });
+
+  // We send to background.js our current sync status used for metrics cd10
+  chrome.runtime.sendMessage({
+    action: 'redux',
+    sync: store.getState().sync
+  });
+
   return next(action);
 };
 

--- a/src/sidebar/app/store.js
+++ b/src/sidebar/app/store.js
@@ -12,7 +12,7 @@ const storeState = store => next => action => {
     redux: JSON.stringify(store.getState())
   });
 
-  // We send to background.js our current sync status used for metrics cd10
+  // We send to background.js our current sync status used for metrics `cd10`
   chrome.runtime.sendMessage({
     action: 'redux',
     sync: store.getState().sync


### PR DESCRIPTION
Add cd10 to every metrics request. Possible values are: **'error', 'isSyncing', 'synced', 'openLogin', 'verifyAccount', 'reconnectSync', and 'signIn'**.
Names are the one used by front-end to display proper footer UI.

We are not able for now to detect if a user synced on more than one device. This should be an improvement while working on the v5.mobile app.

Fix #771 