### PR TITLE
Fix CSS transition on Windows

### DIFF
--- a/src/sidebar/static/scss/menu.scss
+++ b/src/sidebar/static/scss/menu.scss
@@ -15,8 +15,8 @@
   }
 
   &.close {
-    &.top .wrapper { bottom: 39px; }
-    &.bottom .wrapper { top: 33px; }
+    &.top .wrapper { bottom: 35px; }
+    &.bottom .wrapper { top: 29px; }
     .wrapper {
       visibility: hidden;
       opacity: 0;


### PR DESCRIPTION
Fixes #845

Sadly we cannot do a nice transition on Windows because then text is super shaky, sorry @sebastienbarbier  :(