### PR TITLE
Fix formating on title if first item is a list

### DIFF
--- a/src/sidebar/app/utils/utils.js
+++ b/src/sidebar/app/utils/utils.js
@@ -50,7 +50,7 @@ function getFirstNonEmptyElement(parentElement) {
 function getFirstLineFromContent(content) {
   // assign contents to container element for later parsing
   const parentElement = document.createElement('div');
-  parentElement.innerHTML = content; // eslint-disable-line no-unsanitized/property
+  parentElement.innerHTML = content.replace(/<\/p>|<\/li>/gi, '&nbsp;'); // eslint-disable-line no-unsanitized/property
 
   const element = getFirstNonEmptyElement(parentElement);
 


### PR DESCRIPTION
The title of a note is wrongly displayed if the note contains only a list. This is now fixed 👍

Fix #861