### PR TITLE
Refactor events workflow

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -15,7 +15,6 @@ let closeUI = null;
 let isEditorReady = false;
 
 // Kinto sync and encryption
-
 const client = new Kinto({remote: KINTO_SERVER, bucket: 'default'});
 
 // Analytics

--- a/src/background.js
+++ b/src/background.js
@@ -198,14 +198,19 @@ browser.runtime.onMessage.addListener(function(eventData) {
         browser.runtime.sendMessage({
           action: 'create-note',
           id: result.data.id,
-          content: result.data.content
+          content: result.data.content,
+          lastModified: result.data.lastModified
         });
       });
       break;
     case 'delete-note':
       // We create a note, and send id with note-created nessage
-      deleteNote(client, eventData.id).then((note) => {
-        loadFromKinto(client, credentials);
+      deleteNote(client, eventData.id).then(() => {
+        // loadFromKinto(client, credentials);
+        browser.runtime.sendMessage({
+          action: 'delete-note',
+          id: eventData.id
+        });
       });
       break;
     case 'theme-changed':

--- a/src/background.js
+++ b/src/background.js
@@ -164,9 +164,6 @@ browser.runtime.onMessage.addListener(function(eventData) {
     case 'kinto-sync':
       loadFromKinto(client, credentials);
       break;
-    case 'kinto-save':
-      saveToKinto(client, credentials, eventData.note);
-      break;
     case 'metrics-changed':
       sendMetrics('changed', eventData.context);
       break;
@@ -202,6 +199,9 @@ browser.runtime.onMessage.addListener(function(eventData) {
           lastModified: result.data.lastModified
         });
       });
+      break;
+    case 'update-note':
+      saveToKinto(client, credentials, eventData.note, eventData.from);
       break;
     case 'delete-note':
       // We create a note, and send id with note-created nessage

--- a/src/sidebar/app/actions.js
+++ b/src/sidebar/app/actions.js
@@ -1,5 +1,6 @@
 import { SYNC_AUTHENTICATED,
          KINTO_LOADED,
+         TEXT_SAVED,
          TEXT_SYNCED,
          RECONNECT_SYNC,
          DISCONNECTED,
@@ -22,20 +23,23 @@ import * as FileSaver from 'file-saver';
 /*
  * action creators
  */
+export function updatedNote(id, content, lastModified) {
+  return { type: UPDATE_NOTE, id, content, lastModified };
+}
 export function updateNote(id, content) {
-  let isInitialContent = false;
   const lastModified = new Date();
   if (content.replace(/&nbsp;/g, '\xa0') !== INITIAL_CONTENT.replace(/\s\s+/g, ' ')) {
-    chrome.runtime.sendMessage({
-      action: 'kinto-save',
-      note: {
-        id, content, lastModified
-      }
+    browser.windows.getCurrent({populate: true}).then((windowInfo) => {
+      chrome.runtime.sendMessage({
+        action: UPDATE_NOTE,
+        from: windowInfo.id,
+        note: {
+          id, content, lastModified
+        }
+      });
     });
-  } else {
-    isInitialContent = true;
   }
-  return { type: UPDATE_NOTE, id, content, lastModified, isInitialContent };
+  return { type: UPDATE_NOTE, id, content, lastModified };
 }
 
 export function authenticate(email) {
@@ -44,6 +48,10 @@ export function authenticate(email) {
     action: 'kinto-sync'
   });
   return { type: SYNC_AUTHENTICATED, email };
+}
+
+export function saved(id, content, lastModified) {
+  return { type: TEXT_SAVED, id, content, lastModified };
 }
 
 export function synced(notes) {

--- a/src/sidebar/app/actions.js
+++ b/src/sidebar/app/actions.js
@@ -81,6 +81,9 @@ export function reconnectSync() {
   return { type: RECONNECT_SYNC };
 }
 
+export function createdNote(id, content, lastModified) {
+  return { type: CREATE_NOTE, id, content, lastModified };
+}
 export function createNote(content = '') {
 
   const id = uuid4();
@@ -104,16 +107,15 @@ export function createNote(content = '') {
   return fct;
 }
 
-export function deleteNote(id) {
-
-  id ? chrome.runtime.sendMessage({ action: 'delete-note', id }) : null;
-
-  browser.runtime.sendMessage({
-    action: 'kinto-sync'
-  });
-
+export function deletedNote(id) {
   return { type: DELETE_NOTE, id };
 }
+export function deleteNote(id) {
+
+  chrome.runtime.sendMessage({ action: 'delete-note', id });
+  return { type: DELETE_NOTE, id };
+}
+
 
 // EXPORT HTML
 export function exportHTML(content) {

--- a/src/sidebar/app/components/Editor.js
+++ b/src/sidebar/app/components/Editor.js
@@ -6,7 +6,7 @@ import { getPadStats, customizeEditor } from '../utils/editor';
 
 import INITIAL_CONFIG from '../data/editorConfig';
 
-import { updateNote } from '../actions';
+import { updateNote, createNote, deleteNote, setFocusedNote } from '../actions';
 
 const styles = {
   container: {
@@ -44,7 +44,15 @@ class Editor extends React.Component {
                 const content = editor.getData();
 
                 if (!this.ignoreChange) {
-                  this.props.dispatch(updateNote(this.props.note.id, content));
+                  if (!this.props.note.id) {
+                    this.props.dispatch(createNote(content)).then(id => {
+                      this.props.dispatch(setFocusedNote(id));
+                    });
+                  } else if (this.props.note.id && (content === '' || content === '<p>&nbsp;</p>')) {
+                    this.props.dispatch(deleteNote(this.props.note.id));
+                  } else {
+                    this.props.dispatch(updateNote(this.props.note.id, content));
+                  }
                 }
                 this.ignoreChange = false;
 
@@ -77,7 +85,9 @@ class Editor extends React.Component {
   }
 
   componentWillUnmount() {
-    this.editor.destroy();
+    if (this.editor) {
+      this.editor.destroy();
+    }
   }
 
   render() {
@@ -89,7 +99,7 @@ class Editor extends React.Component {
             ref={node => {
               this.node = node;
             }}
-            dangerouslySetInnerHTML={{ __html: this.props.note.content || '' }}>
+            dangerouslySetInnerHTML={{ __html: this.props.note ? this.props.note.content : '' }}>
           </div>
         </div>
 
@@ -112,7 +122,8 @@ function mapStateToProps(state) {
 
 Editor.propTypes = {
     state: PropTypes.object.isRequired,
-    note: PropTypes.object.isRequired,
+    history: PropTypes.object.isRequired,
+    note: PropTypes.object,
     dispatch: PropTypes.func.isRequired
 };
 

--- a/src/sidebar/app/components/EditorPanel.js
+++ b/src/sidebar/app/components/EditorPanel.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import Header from './Header';
 import Editor from './Editor';
 
-import { createNote, setFocusedNote } from '../actions';
+import { setFocusedNote } from '../actions';
 
 class EditorPanel extends React.Component {
 
@@ -15,16 +15,16 @@ class EditorPanel extends React.Component {
     this.props = props;
 
     this.note = {}; // Note should be reference to state.
-    this.note = props.state.notes.find((note) => {
-      return note.id === props.match.params.id;
-    });
-    this.props.dispatch(setFocusedNote(props.match.params.id));
+    if (props.match.params.id) {
+      this.note = props.state.notes.find((note) => {
+        return note.id === props.match.params.id;
+      });
+      this.props.dispatch(setFocusedNote(props.match.params.id));
+    }
 
     this.onNewNoteEvent = () => {
-      // Request new id and redirec to new note
-      this.props.dispatch(createNote()).then(id => {
-        props.history.push(`/note/${id}`);
-      });
+      this.props.dispatch(setFocusedNote());
+      props.history.push('/note');
     };
   }
 
@@ -36,27 +36,27 @@ class EditorPanel extends React.Component {
 
   // This is triggered when redux update state.
   componentWillReceiveProps(nextProps) {
-    if (nextProps.match.params.id !== this.props.match.params.id) {
+    if (this.props.state.sync.focusedNoteId !== nextProps.state.sync.focusedNoteId) {
       this.note = nextProps.state.notes.find((note) => {
-        return note.id === nextProps.match.params.id;
+        return note.id === nextProps.state.sync.focusedNoteId;
       });
-      this.props.dispatch(setFocusedNote(nextProps.match.params.id));
+      this.props.dispatch(setFocusedNote(nextProps.state.sync.focusedNoteId));
     } else if (!this.props.state.sync.isSyncing) {
       this.note = nextProps.state.notes.find((note) => {
-        return note.id === nextProps.match.params.id;
+        return note.id === nextProps.state.sync.focusedNoteId;
       });
     }
 
     if (!this.note) {
       this.note = {};
-      this.props.history.push('/');
+      // this.props.history.push('/');
     }
   }
 
   render() {
     return [
       <Header key="header" history={this.props.history} note={this.note} onNewNoteEvent={this.onNewNoteEvent} />,
-      <Editor key="editor" note={this.note} />
+      <Editor key="editor" history={this.props.history} note={this.note} />
     ];
   }
 }

--- a/src/sidebar/app/components/Header.js
+++ b/src/sidebar/app/components/Header.js
@@ -162,7 +162,7 @@ function mapStateToProps(state) {
 Header.propTypes = {
     state: PropTypes.object.isRequired,
     history: PropTypes.object.isRequired,
-    note: PropTypes.object.isRequired,
+    note: PropTypes.object,
     onNewNoteEvent: PropTypes.func.isRequired,
     dispatch: PropTypes.func.isRequired
 };

--- a/src/sidebar/app/components/ListPanel.js
+++ b/src/sidebar/app/components/ListPanel.js
@@ -32,10 +32,6 @@ class ListPanel extends React.Component {
         this.props.history.push(`/note/${id}`);
       });
     } else {
-      // We delete notes with no content
-      const listOfEmptyNote = this.props.state.notes.filter((n) => !n.firstLine ).map((n) => n.id);
-      listOfEmptyNote.forEach((id) => this.props.dispatch(deleteNote(id)));
-
       // Set no focused Note to create new note on send note event.
       this.props.dispatch(setFocusedNote());
     }
@@ -68,7 +64,7 @@ class ListPanel extends React.Component {
           <NewIcon /> <span>{ browser.i18n.getMessage('newNote') }</span>
         </button>
         <ul>
-          { this.props.state.notes.filter((note) => note.firstLine ).sort((a, b) => {
+          { this.props.state.notes.sort((a, b) => {
             if (a.lastModified.getTime() !== b.lastModified.getTime()) {
               return a.lastModified.getTime() < b.lastModified.getTime() ? 1 : -1;
             }
@@ -79,8 +75,17 @@ class ListPanel extends React.Component {
                 <button
                   onClick={ () => this.props.history.push(`/note/${note.id}`) }
                   className="btn fullWidth borderBottom">
-                  <p><strong>{ note.firstLine }</strong></p>
-                  <p><span>{ formatLastModified(note.lastModified) }</span> { note.secondLine }</p>
+                  { note.firstLine ?
+                  <div>
+                    <p><strong>{ note.firstLine }</strong></p>
+                    <p><span>{ formatLastModified(note.lastModified) }</span> { note.secondLine }</p>
+                  </div>
+                  :
+                  <div style={{ opacity: '0.4' }}>
+                    <p><strong>{ browser.i18n.getMessage('emptyPlaceHolder') }</strong></p>
+                    <p><span>{ formatLastModified(note.lastModified) }</span></p>
+                  </div>
+                  }
                 </button>
               </li>
             );

--- a/src/sidebar/app/components/ListPanel.js
+++ b/src/sidebar/app/components/ListPanel.js
@@ -16,10 +16,8 @@ class ListPanel extends React.Component {
     this.props = props;
 
     this.requestNewNote = () => {
-      // Request not id from background.
-      this.props.dispatch(createNote()).then(id => {
-        props.history.push(`/note/${id}`);
-      });
+      props.dispatch(setFocusedNote());
+      props.history.push('/note');
     };
   }
 

--- a/src/sidebar/app/components/ListPanel.js
+++ b/src/sidebar/app/components/ListPanel.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import INITIAL_CONTENT from '../data/initialContent';
 
 import NewIcon from './icons/NewIcon';
-import { deleteNote, setFocusedNote, createNote } from '../actions';
+import { setFocusedNote, createNote } from '../actions';
 import { formatLastModified } from '../utils/utils';
 
 

--- a/src/sidebar/app/onMessage.js
+++ b/src/sidebar/app/onMessage.js
@@ -2,6 +2,8 @@ import { SYNC_AUTHENTICATED,
          KINTO_LOADED,
          UPDATE_NOTE,
          TEXT_SYNCED,
+         CREATE_NOTE,
+         DELETE_NOTE,
          RECONNECT_SYNC,
          DISCONNECTED,
          ERROR,
@@ -10,6 +12,8 @@ import { SYNC_AUTHENTICATED,
 import { authenticate,
          disconnect,
          createNote,
+         createdNote,
+         deletedNote,
          synced,
          reconnectSync,
          sendToNote,
@@ -54,6 +58,12 @@ chrome.runtime.onMessage.addListener(eventData => {
         } else {
           store.dispatch(synced());
         }
+        break;
+      case CREATE_NOTE:
+        store.dispatch(createdNote(eventData.id, eventData.content, eventData.lastModified));
+        break;
+      case DELETE_NOTE:
+        store.dispatch(deletedNote(eventData.id));
         break;
       case RECONNECT_SYNC:
         store.dispatch(reconnectSync());

--- a/src/sidebar/app/reducers.js
+++ b/src/sidebar/app/reducers.js
@@ -62,6 +62,7 @@ function sync(sync = {}, action) {
     case DELETE_NOTE:
       return Object.assign({}, sync, {
         isSyncing: true,
+        focusedNoteId: sync.focusedNoteId === action.id ? null : sync.focusedNoteId,
         error: null
       });
     case UPDATE_NOTE:

--- a/src/sidebar/app/reducers.js
+++ b/src/sidebar/app/reducers.js
@@ -148,13 +148,13 @@ function notes(notes = [], action) {
       return res;
     }
     case CREATE_NOTE: {
-      const list = Array.from(notes);
+      const list = Array.from(notes).filter((note) => note.id !== action.id);
       list.push({
         id: action.id,
         content: action.content,
         firstLine: getFirstLineFromContent(action.content),
         secondLine: stripHtmlWithoutFirstLine(action.content),
-        lastModified: new Date()
+        lastModified: action.lastModified || new Date()
       });
       return list;
     }

--- a/src/sidebar/app/reducers.js
+++ b/src/sidebar/app/reducers.js
@@ -2,6 +2,7 @@ import { combineReducers } from 'redux';
 import {
   SYNC_AUTHENTICATED,
   DISCONNECTED,
+  TEXT_SAVED,
   TEXT_SYNCED,
   KINTO_LOADED,
   OPENING_LOGIN,
@@ -69,6 +70,10 @@ function sync(sync = {}, action) {
       return Object.assign({}, sync, {
         isSyncing: true,
         error: null
+      });
+    case TEXT_SAVED:
+      return Object.assign({}, sync, {
+        isSyncing: sync.email ? sync.isSyncing : false
       });
     case TEXT_SYNCED:
       return Object.assign({}, sync, {
@@ -162,14 +167,20 @@ function notes(notes = [], action) {
       return Array.from(notes).filter((note) => note.id !== action.id);
     case UPDATE_NOTE: {
       const list = Array.from(notes);
-      const note = list.find((note) => {
-        return note.id === action.id;
-      });
+      const note = list.find((note) => note.id === action.id);
       if (note) {
         note.content = action.content;
         note.firstLine = getFirstLineFromContent(action.content);
         note.secondLine = stripHtmlWithoutFirstLine(action.content);
         note.lastModified = new Date(action.lastModified);
+      } else {
+        list.push({
+          id: action.id,
+          content: action.content,
+          firstLine: getFirstLineFromContent(action.content),
+          secondLine: stripHtmlWithoutFirstLine(action.content),
+          lastModified: new Date(action.lastModified)
+        });
       }
       return list;
     }

--- a/src/sidebar/app/router.js
+++ b/src/sidebar/app/router.js
@@ -19,6 +19,7 @@ class Router extends React.Component {
       <HashRouter>
         <div style={styles.container}>
           <Route exact path="/" component={ListPanel} />
+          <Route exact path="/note" component={EditorPanel} />
           <Route exact path="/note/:id" component={EditorPanel} />
         </div>
       </HashRouter>

--- a/src/sidebar/app/utils/constants.js
+++ b/src/sidebar/app/utils/constants.js
@@ -5,6 +5,7 @@ export const SURVEY_PATH = 'https://qsurvey.mozilla.com/s3/notes?ref=sidebar';
 // FOR LEGACY, THOSE STRING MATCH THE ONE USED IN BACKGROUND.js
 export const SYNC_AUTHENTICATED = 'sync-authenticated';
 export const KINTO_LOADED = 'kinto-loaded';
+export const TEXT_SAVED = 'text-saved';
 export const TEXT_SYNCED = 'text-synced';
 export const OPENING_LOGIN = 'opening-login';
 export const PLEASE_LOGIN = 'please-login';
@@ -15,7 +16,7 @@ export const EXPORT_HTML = 'export-html';
 
 // CRUD actions on note
 export const CREATE_NOTE = 'create-note';
-export const UPDATE_NOTE = 'text-change';
+export const UPDATE_NOTE = 'update-note';
 export const DELETE_NOTE = 'delete-note';
 
 export const FOCUS_NOTE = 'focus-note';

--- a/src/sync.js
+++ b/src/sync.js
@@ -406,7 +406,9 @@ function saveToKinto(client, credentials, note) { // eslint-disable-line no-unus
 }
 
 function createNote(client, note) { // eslint-disable-line no-unused-vars
-  return client.collection('notes', { idSchema: notesIdSchema }).create(note, { useRecordId: true });
+  return client
+    .collection('notes', { idSchema: notesIdSchema })
+    .create(note, { useRecordId: true });
 }
 
 function deleteNote(client, id) { // eslint-disable-line no-unused-vars

--- a/src/sync.js
+++ b/src/sync.js
@@ -358,6 +358,10 @@ function saveToKinto(client, credentials, note, fromWindowId) { // eslint-disabl
     resolve = thisResolve;
   });
 
+  browser.runtime.sendMessage('notes@mozilla.com', {
+    action: 'text-editing'
+  });
+
   const later = function() {
     syncDebounce = null;
     const notes = client.collection('notes', { idSchema: notesIdSchema });
@@ -365,7 +369,7 @@ function saveToKinto(client, credentials, note, fromWindowId) { // eslint-disabl
       .then((res) => {
         browser.runtime.sendMessage('notes@mozilla.com', {
           action: 'text-saved',
-          note: res.data,
+          note: res ? res.data : undefined,
           from: fromWindowId
         });
         client.conflict = false;
@@ -387,7 +391,7 @@ function saveToKinto(client, credentials, note, fromWindowId) { // eslint-disabl
       .catch(result => {
         browser.runtime.sendMessage('notes@mozilla.com', {
           action: 'text-synced',
-          note: result.data.find((n) => n.id === note.id),
+          note: undefined,
           conflict: client.conflict,
           from: fromWindowId
         });

--- a/test/unit/main.test.js
+++ b/test/unit/main.test.js
@@ -350,7 +350,7 @@ describe('Authorization', function() {
     it('should not fail if syncKinto rejects', () => {
       const syncKinto = sandbox.stub(global, 'syncKinto').rejects('server busy playing Minesweeper');
       collection.getAny.resolves({data: {last_modified: 'abc', content: 'def'}});
-      return saveToKinto(client, undefined, { content: 'imaginary content' })
+      return saveToKinto(client, undefined, { content: 'imaginary content' }, 1)
         .then(() => {
           chai.assert(browser.runtime.sendMessage.calledThrice);
           chai.expect(browser.runtime.sendMessage.getCall(0).args[0]).eql('notes@mozilla.com');
@@ -360,12 +360,15 @@ describe('Authorization', function() {
           chai.expect(browser.runtime.sendMessage.getCall(1).args[0]).eql('notes@mozilla.com');
           chai.expect(browser.runtime.sendMessage.getCall(1).args[1]).eql({
             action: 'text-saved',
+            note: undefined,
+            from:1
           });
           chai.expect(browser.runtime.sendMessage.getCall(2).args[0]).eql('notes@mozilla.com');
           chai.expect(browser.runtime.sendMessage.getCall(2).args[1]).eql({
-            action: 'text-synced',
-            notes: undefined,
-            conflict: false
+            action:'text-synced',
+            note: undefined,
+            conflict:false,
+            from:1
           });
         });
     });


### PR DESCRIPTION
Having many issue syncing between multi-window notes, our data workflow was designed for single note. We were triggering `kinto-sync` on every event, performed asynchronously it was causing issues on create/delete/modify events.
Now we share events individually.

Fix #831 #858  