### PR TITLE
Fix wrong timestamp on delete

### DIFF
--- a/src/sync.js
+++ b/src/sync.js
@@ -97,6 +97,13 @@ class JWETransformer {
       decoded.last_modified = record.last_modified;
     }
 
+    // If note has no lastModified (like singleNote from v3), we use kinto last_modified value.
+    // kinto last_modified is a timestamp
+    if (!decoded.lastModified && decoded.last_modified) {
+      decoded.lastModified = new Date(decoded.last_modified);
+    }
+
+
     // _status: deleted records were deleted on a client, but
     // uploaded as an encrypted blob so we don't leak deletions.
     // If we get such a record, flag it as deleted.


### PR DESCRIPTION
This was caused by singleNote in v3 not having a lastModified date. 
After migration, when retrieving notes from kinto we were just ignoring this missing field and our UI was using new date() on load instead, causing this unwanted refresh.

This PR will check if every note has a lastModified value, and if not we will calculate it based on kinto last_modified record value.

Fix #868