### PR TITLE
Fix broken send-to-notes on empty note

### DIFF
--- a/src/sidebar/app/components/Editor.js
+++ b/src/sidebar/app/components/Editor.js
@@ -35,7 +35,7 @@ class Editor extends React.Component {
           }
         });
       }
-    }
+    };
   }
 
   componentDidMount() {

--- a/src/sidebar/app/components/ListPanel.js
+++ b/src/sidebar/app/components/ListPanel.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
 import INITIAL_CONTENT from '../data/initialContent';
+import { SEND_TO_NOTES } from '../utils/constants';
 
 import NewIcon from './icons/NewIcon';
 import { setFocusedNote, createNote } from '../actions';
@@ -19,9 +20,21 @@ class ListPanel extends React.Component {
       props.dispatch(setFocusedNote());
       props.history.push('/note');
     };
+
+    this.sendToNoteListener = (eventData) => {
+      if (eventData.action === SEND_TO_NOTES) {
+        browser.windows.getCurrent({populate: true}).then((windowInfo) => {
+          if (windowInfo.id === eventData.windowId) {
+            this.props.dispatch(createNote(`<p>${eventData.text}</p>`));
+          }
+        });
+      }
+    }
   }
 
   componentWillMount() {
+
+    chrome.runtime.onMessage.addListener(this.sendToNoteListener);
 
     // If user is not logged, and has no notes, we create initial content for him
     // and redirect to it.
@@ -51,6 +64,7 @@ class ListPanel extends React.Component {
   }
 
   componentWillUnmount() {
+    chrome.runtime.onMessage.removeListener(this.sendToNoteListener);
     clearTimeout(this.timer);
   }
 

--- a/src/sidebar/app/components/ListPanel.js
+++ b/src/sidebar/app/components/ListPanel.js
@@ -29,7 +29,7 @@ class ListPanel extends React.Component {
           }
         });
       }
-    }
+    };
   }
 
   componentWillMount() {

--- a/src/sidebar/app/components/ListPanel.js
+++ b/src/sidebar/app/components/ListPanel.js
@@ -30,7 +30,7 @@ class ListPanel extends React.Component {
         });
       }
     };
-    
+
     this.checkInitialContent = (state) => {
       if (state.sync.welcomePage && state.kinto.isLoaded && state.notes.length === 0) {
         this.props.dispatch(createNote(INITIAL_CONTENT)).then(id => {

--- a/src/sidebar/app/onMessage.js
+++ b/src/sidebar/app/onMessage.js
@@ -93,31 +93,6 @@ chrome.runtime.onMessage.addListener(eventData => {
           store.dispatch(disconnect());
         }
         break;
-      case SEND_TO_NOTES: {
-        browser.windows.getCurrent({populate: true}).then((windowInfo) => {
-          if (windowInfo.id === eventData.windowId) {
-            const focusedNoteId = store.getState().sync.focusedNoteId;
-            // If a note is focused/open, we add content at the end.
-            if (focusedNoteId) {
-              const note = store.getState().notes.find((note) => {
-                return note.id === focusedNoteId;
-              });
-              if (note) {
-                if (note.content === '<p>&nbsp;</p>') note.content = '';
-                note.content = note.content + `<p>${eventData.text}</p>`;
-                store.dispatch(updateNote(note.id, note.content));
-              } else {
-                console.error('FocusedNote not in redux state.'); // eslint-disable-line no-console
-              }
-            } else {
-              store.dispatch(createNote(`<p>${ eventData.text }</p>`)).then(() => {
-                store.dispatch(synced());
-              });
-            }
-          }
-        });
-        break;
-      }
     }
 });
 

--- a/src/sidebar/app/onMessage.js
+++ b/src/sidebar/app/onMessage.js
@@ -6,20 +6,17 @@ import { SYNC_AUTHENTICATED,
          DELETE_NOTE,
          RECONNECT_SYNC,
          DISCONNECTED,
-         ERROR,
-         SEND_TO_NOTES } from './utils/constants';
+         ERROR } from './utils/constants';
          // Actions
 import { authenticate,
          disconnect,
-         createNote,
          createdNote,
-         updatedNote,
          deletedNote,
          saved,
          synced,
          reconnectSync,
          kintoLoad,
-         updateNote,
+         updatedNote,
          error } from './actions';
 import store from './store';
 /**


### PR DESCRIPTION
Now works as expected.

Send-to-notes event has to be handle inside component instead of onMessage.js to be properly handled. Alternative is to share in redux state our navigation and have specific behaviour based on url but does not seams easier to maintain.

Fix #877