### PR TITLE
Delay redux disconnect event to avoid empty UI on logout

### DIFF
--- a/native/app/components/DrawerItems.js
+++ b/native/app/components/DrawerItems.js
@@ -48,7 +48,11 @@ class DrawerItems extends React.Component {
       {
         label : 'Log out',
         action: () => {
-          props.dispatch(disconnect()).then(navigateToLogin(props));
+          navigateToLogin(props);
+          // We delay disconnect event to avoid empty UI while drawer is closing
+          setTimeout(() => {
+            props.dispatch(disconnect());
+          }, 500);
         }
       },
       {


### PR DESCRIPTION
You can guess that I am not super happy about how this PR has been implemented, but it works and catching drawer closing events does not seam like an easy option 😥.

![logoutui](https://user-images.githubusercontent.com/3018618/39121022-866785c8-471a-11e8-800a-e9ae8a50887a.gif)

Fix #968 