### PR TITLE
Add firstLine/secondLine generator on update action

### DIFF
--- a/native/app/reducers.js
+++ b/native/app/reducers.js
@@ -208,8 +208,8 @@ function notes(notes = [], action) {
       const note = list.find((note) => note.id === action.id);
       if (note) {
         note.content = action.content;
-        note.firstLine = (action.content);
-        note.secondLine = (action.content);
+        note.firstLine = firstLine(action.content);
+        note.secondLine = secondLine(action.content);
         note.lastModified = new Date(action.lastModified);
       } else if (action.id) {
         list.push({


### PR DESCRIPTION
Looks like we forgot one use case when updating a note and generating firstLine/secondLine used in listPanel. This PR fixes it.

Fix #1000 