### PR TITLE
Application no longer remains "offline" even after logging in.

### DIFF
--- a/native/app/reducers.js
+++ b/native/app/reducers.js
@@ -65,7 +65,8 @@ function sync(sync = {}, action) {
         isPleaseLogin: false,
         isReconnectSync: false,
         error: null,
-        selected: null
+        selected: null,
+        isConnected: true
       });
     case OPENING_LOGIN:
       return Object.assign({}, sync, {


### PR DESCRIPTION
If a user is offine on logout, he should not be able to login. Assuming this, we now set `isConnected` as `true` on logout event 👍

Fix #1063