### PR TITLE
Improve undo button on delete snackbar

### DIFF
--- a/native/app/components/ListPanel.js
+++ b/native/app/components/ListPanel.js
@@ -194,6 +194,7 @@ class ListPanel extends React.Component {
       }
     } else {
       this.snackbarList = [];
+      this._hideSnackbar();
     }
   }
 

--- a/native/app/components/ListPanel.js
+++ b/native/app/components/ListPanel.js
@@ -96,6 +96,7 @@ class ListPanel extends React.Component {
         }).start();
       } else {
         this.snackbarList.push(snackbar);
+        this._hideSnackbar();
       }
     };
 

--- a/native/app/components/ListPanel.js
+++ b/native/app/components/ListPanel.js
@@ -122,10 +122,16 @@ class ListPanel extends React.Component {
     };
 
     this._undoDelete = () => {
-      this._hideSnackbar();
-      this.state.deletedNote.forEach((note) => {
-        props.dispatch(createNote(note));
-      });
+
+      const promises = [];
+
+      if (this.state.deletedNote) {
+        this.state.deletedNote.forEach((note) => {
+          promises.push(props.dispatch(createNote(note)));
+        });
+      }
+
+      Promise.all(promises).then(this._hideSnackbar, this._hideSnackbar);
     };
   }
 

--- a/native/app/components/Snackbar.js
+++ b/native/app/components/Snackbar.js
@@ -248,18 +248,18 @@ class Snackbar extends React.Component<Props, State> {
                 {children}
               </Text>
               {action ? (
-                <View
-                  style={{
-                    marginHorizontal: buttonMargin,
-                  }}
-                >
+                <View>
                   <TouchableWithoutFeedback
                     onPress={() => {
                       action.onPress();
                       this._hide();
                     }}
                   >
-                    <View>
+                    <View
+                      style={{
+                        paddingHorizontal: buttonMargin,
+                        paddingVertical: 12
+                      }}>
                       <Text style={{ color: colors.accent }}>
                         {action.text.toUpperCase()}
                       </Text>

--- a/native/app/components/Snackbar.js
+++ b/native/app/components/Snackbar.js
@@ -223,7 +223,7 @@ class Snackbar extends React.Component<Props, State> {
             style,
           ]}
         >
-          <TouchableWithoutFeedback onPress={onDismiss}>
+          <TouchableWithoutFeedback onPress={!action ? onDismiss : null}>
             <Animated.View
               style={[
                 styles.container,


### PR DESCRIPTION
- [x] Catch crash if user double click on undo button. (fix #1075)
- [x] Also make click-able area bigger (fix #1076)
- [x] Disable click oustide of undo button (fix #1043)

Fixes https://github.com/mozilla/notes/issues/1083