### PR TITLE
Fix double tap on the hamburger menu

### DIFF
--- a/native/app/components/ListPanelHeader.js
+++ b/native/app/components/ListPanelHeader.js
@@ -60,7 +60,7 @@ class ListPanelHeader extends Component {
           style={{ paddingTop: 4 }}
           color={COLOR_NOTES_BLUE}
           icon='menu'
-          onPress={() => navigation.openDrawer()} />
+          onPress={() => navigation.toggleDrawer()} />
         <ToolbarContent
           style={{ paddingLeft: 0,  }}
           titleStyle={{ fontSize: 18, color: COLOR_NOTES_BLUE }}


### PR DESCRIPTION
Was no longer openning. Tap was triggering openMenu(), now will trigger toggleMenu().
Fix #1077