### PR TITLE
Fix paper theme loading and double transform error on FAB button

### DIFF
--- a/native/app/components/ListPanel.js
+++ b/native/app/components/ListPanel.js
@@ -259,11 +259,13 @@ class ListPanel extends React.Component {
                     inputRange: [0, SNACKBAR_HEIGHT],
                     outputRange: [-1 * SNACKBAR_HEIGHT, 0]
                   }),
+                },
+                {
                   scale: this.state.fabOpacityAnimation.interpolate({
                     inputRange: [0, 1],
                     outputRange: [0.9, 1]
                   }),
-                },
+                }
               ],
             }]}>
             <FAB

--- a/native/index.js
+++ b/native/index.js
@@ -160,7 +160,9 @@ class Notes extends React.Component {
     return (
       <StoreProvider store={store}>
         <PersistGate loading={null} persistor={persistor}>
-          <App/>
+          <PaperProvider>
+            <App/>
+          </PaperProvider>
         </PersistGate>
       </StoreProvider>
     )


### PR DESCRIPTION
I have two intermittent errors on master happening when starting the app:

> TypeError: Cannot read property 'colors' of undefined
> 
> This error is located at:
>     in StyledText (at withTheme.js:75)
>     in withTheme(StyledText) (at Title.js:29)
>     in Title (at DrawerItems.js:177)

Solved by adding `<PaperProvider>`  around our `<App>` component to load defaultTheme I guess _(we keep a second provider to keep the snackbar behind the drawer)_.

>  Invariant Violation: You must specify exactly one property per transform object. Passed properties: {"translateY":0,"scale":1}

Solved by fixing a syntax error which was not reported before.