### PR TITLE
ReconnectSync workflow using Snackbar

### DIFF
--- a/native/app/actions.js
+++ b/native/app/actions.js
@@ -13,6 +13,7 @@ import { SYNC_AUTHENTICATED,
   FOCUS_NOTE,
   ERROR,
   NET_INFO,
+  RECONNECT_SYNC,
   TOGGLE_SELECT,
   RESET_SELECT } from './utils/constants';
 
@@ -23,6 +24,11 @@ import sync from './utils/sync';
 
 export function pleaseLogin() {
   return { type: PLEASE_LOGIN };
+}
+
+export function reconnectSync() {
+  trackEvent('reconnect-sync');
+  return { type: RECONNECT_SYNC, message: 'Reconnect to Sync' };
 }
 
 export function syncing() {

--- a/native/app/actions.js
+++ b/native/app/actions.js
@@ -12,6 +12,8 @@ import { SYNC_AUTHENTICATED,
   DELETE_NOTE,
   FOCUS_NOTE,
   ERROR,
+  OPENING_LOGIN,
+  PLEASE_LOGIN,
   NET_INFO,
   RECONNECT_SYNC,
   TOGGLE_SELECT,
@@ -24,6 +26,10 @@ import sync from './utils/sync';
 
 export function pleaseLogin() {
   return { type: PLEASE_LOGIN };
+}
+
+export function openingLogin() {
+  return { type: OPENING_LOGIN };
 }
 
 export function reconnectSync() {
@@ -53,7 +59,9 @@ export function kintoLoad(origin) {
           }
           resolve();
         }).catch((error) => {
-          dispatch(reconnectSync());
+          if (!getState().sync.loginDetails) {
+            dispatch(reconnectSync());
+          }
           resolve();
         });
       }

--- a/native/app/background.js
+++ b/native/app/background.js
@@ -30,16 +30,22 @@ browser.runtime.onMessage.addListener(eventData => {
       sync.createNote(kintoClient, store.getState().sync.loginDetails,
         { id: eventData.id, content: eventData.content, lastModified: eventData.lastModified }).then(() => {
         store.dispatch({ type: TEXT_SYNCED });
+      }).catch(() => {
+        store.dispatch({ type: TEXT_SYNCED });
       });
       break;
     case UPDATE_NOTE:
       sync.saveToKinto(kintoClient, store.getState().sync.loginDetails,
         { id: eventData.id, content: eventData.content, lastModified: eventData.lastModified }).then(() => {
         store.dispatch({ type: TEXT_SYNCED });
+      }).catch(() => {
+        store.dispatch({ type: TEXT_SYNCED });
       });
       break;
     case DELETE_NOTE:
       sync.deleteNotes(kintoClient, store.getState().sync.loginDetails, eventData.ids, eventData.origin).then(() => {
+        store.dispatch({ type: TEXT_SYNCED });
+      }).catch(() => {
         store.dispatch({ type: TEXT_SYNCED });
       });
       break;

--- a/native/app/background.js
+++ b/native/app/background.js
@@ -1,6 +1,5 @@
 import kintoClient from './vendor/kinto-client';
 import fxaUtils from './vendor/fxa-utils';
-import { trackEvent } from './utils/metrics';
 
 import { SYNC_AUTHENTICATED,
   KINTO_LOADED,
@@ -23,6 +22,7 @@ import { SYNC_AUTHENTICATED,
  import browser from './browser';
  import { store, persistor } from './store';
  import sync from './utils/sync';
+ import { reconnectSync } from './actions';
 
 browser.runtime.onMessage.addListener(eventData => {
   switch(eventData.action) {
@@ -54,8 +54,7 @@ browser.runtime.onMessage.addListener(eventData => {
       store.dispatch({ type: ERROR, message: eventData.message });
       break;
     case RECONNECT_SYNC:
-      trackEvent('reconnect-sync');
-      store.dispatch({ type: ERROR, message: 'Reconnect to Sync' });
+      store.dispatch(reconnectSync());
     default:
       break;
   }

--- a/native/app/components/DrawerItems.js
+++ b/native/app/components/DrawerItems.js
@@ -105,7 +105,7 @@ class DrawerItems extends React.Component {
     };
 
     this._requestReconnect = () => {
-      if (!this.props.state.profile.email) {
+      if (!this.props.state.sync.loginDetails) {
         this.setState({ isOpeningLogin: true });
         return Promise.resolve().then(() => {
           this.props.dispatch(syncing());

--- a/native/app/components/DrawerItems.js
+++ b/native/app/components/DrawerItems.js
@@ -93,7 +93,7 @@ class DrawerItems extends React.Component {
           props.navigation.dispatch(DrawerActions.closeDrawer());
           ToastAndroid.show('You are offline.', ToastAndroid.LONG);
         }
-      } else if (!this.props.state.profile.email) {
+      } else if (!this.props.state.sync.loginDetails) {
         this._requestReconnect();
       } else {
         trackEvent('webext-button-authenticate');
@@ -108,7 +108,6 @@ class DrawerItems extends React.Component {
       if (!this.props.state.sync.loginDetails) {
         this.setState({ isOpeningLogin: true });
         return Promise.resolve().then(() => {
-          this.props.dispatch(syncing());
           return fxaUtils.launchOAuthKeyFlow();
         }).then((loginDetails) => {
           trackEvent('login-success');
@@ -123,29 +122,6 @@ class DrawerItems extends React.Component {
         });
       }
     };
-  }
-
-  componentDidMount() {
-    const { navigation } = this.props;
-
-    function select(state) {
-      return state.sync.error
-    }
-
-    store.subscribe(() => {
-      const state = store.getState();
-      const err = select(state);
-      const routes = this.props.navigation.state.routes[0].routes;
-      const route = routes[routes.length - 1];
-      if (err && !state.sync.loginDetails) {
-        if (route.routeName === 'EditorPanel') {
-          this.props.navigation.navigate('ListPanel');
-          setTimeout(() => this.props.navigation.dispatch(DrawerActions.openDrawer()), 250);
-        } else {
-          this.props.navigation.dispatch(DrawerActions.openDrawer())
-        }
-      }
-    })
   }
 
   componentWillReceiveProps(newProps) {

--- a/native/app/components/DrawerItems.js
+++ b/native/app/components/DrawerItems.js
@@ -22,7 +22,7 @@ import { trackEvent } from '../utils/metrics';
 import fxaUtils from '../vendor/fxa-utils';
 import { store } from '../store';
 import browser from '../browser';
-import { disconnect, kintoLoad, authenticate, syncing, reconnectSync } from '../actions';
+import { disconnect, kintoLoad, authenticate, syncing, reconnectSync, openingLogin } from '../actions';
 
 // Url to open to give feedback
 const SURVEY_PATH = 'https://qsurvey.mozilla.com/s3/notes?ref=android';
@@ -107,9 +107,9 @@ class DrawerItems extends React.Component {
     this._requestReconnect = () => {
       if (!this.props.state.sync.loginDetails) {
         this.setState({ isOpeningLogin: true });
-        return Promise.resolve().then(() => {
-          return fxaUtils.launchOAuthKeyFlow();
-        }).then((loginDetails) => {
+        this.props.dispatch(openingLogin());
+        return fxaUtils.launchOAuthKeyFlow()
+        .then((loginDetails) => {
           trackEvent('login-success');
           this.setState({ isOpeningLogin: false });
           this.props.dispatch(authenticate(loginDetails));

--- a/native/app/components/DrawerItems.js
+++ b/native/app/components/DrawerItems.js
@@ -108,7 +108,8 @@ class DrawerItems extends React.Component {
       if (!this.props.state.sync.loginDetails) {
         this.setState({ isOpeningLogin: true });
         this.props.dispatch(openingLogin());
-        return fxaUtils.launchOAuthKeyFlow()
+        return Promise.resolve()
+        .then(() => fxaUtils.launchOAuthKeyFlow())
         .then((loginDetails) => {
           trackEvent('login-success');
           this.setState({ isOpeningLogin: false });
@@ -142,7 +143,7 @@ class DrawerItems extends React.Component {
     if (this.props.state.sync.isConnected === false) {
       statusLabel = 'Offline';
     } else if (this.props.state.sync.isSyncing) {
-      statusLabel = 'Syncing...';
+      statusLabel = 'Syncing…';
     } else {
       statusLabel = `Last synced ${ moment(this.props.state.sync.lastSynced).format('LT') }`;
     }
@@ -171,7 +172,7 @@ class DrawerItems extends React.Component {
         { this.props.state.sync.error ?
           <TouchableRipple style={styles.footer} onPress={this._requestReconnect}>
             <View style={styles.footerWrapper}>
-              <Text style={{ color: COLOR_DARK_WARNING, fontSize: 13 }}>{ this.props.state.sync.error }</Text>
+              <Text style={{ color: COLOR_DARK_WARNING, fontSize: 13 }}>{ this.props.state.sync.isOpeningLogin ? 'Opening login…' : this.props.state.sync.error }</Text>
               <MaterialIcons
                 name='warning'
                 style={{ color: COLOR_DARK_WARNING }}

--- a/native/app/components/DrawerItems.js
+++ b/native/app/components/DrawerItems.js
@@ -15,7 +15,6 @@ import { COLOR_DARK_BACKGROUND,
          COLOR_DARK_SYNC,
          COLOR_NOTES_BLUE,
          KINTO_LOADED,
-         RECONNECT_SYNC,
          DISCONNECTED } from '../utils/constants';
 
 import { DrawerItem, DrawerSection, Colors } from 'react-native-paper';
@@ -23,7 +22,7 @@ import { trackEvent } from '../utils/metrics';
 import fxaUtils from '../vendor/fxa-utils';
 import { store } from '../store';
 import browser from '../browser';
-import { disconnect, kintoLoad, authenticate, syncing } from '../actions';
+import { disconnect, kintoLoad, authenticate, syncing, reconnectSync } from '../actions';
 
 // Url to open to give feedback
 const SURVEY_PATH = 'https://qsurvey.mozilla.com/s3/notes?ref=android';
@@ -120,9 +119,7 @@ class DrawerItems extends React.Component {
           });
         }).catch((exception) => {
           this.setState({ isOpeningLogin: false });
-          browser.runtime.sendMessage({
-            action: RECONNECT_SYNC
-          });
+          this.props.dispatch(reconnectSync());
         });
       }
     };

--- a/native/app/components/ListPanel.js
+++ b/native/app/components/ListPanel.js
@@ -204,7 +204,6 @@ class ListPanel extends React.Component {
       } else if (!newProps.state.sync.loginDetails &&
                  !newProps.state.sync.isOpeningLogin &&
                  !newProps.state.sync.isPleaseLogin) {
-        console.log(newProps.state.sync);
         this._showSnackbar({
           text: newProps.state.sync.error,
           color: COLOR_DARK_WARNING,

--- a/native/app/components/ListPanel.js
+++ b/native/app/components/ListPanel.js
@@ -157,7 +157,8 @@ class ListPanel extends React.Component {
 
         this.props.dispatch(openingLogin());
         this.snackbarList = [];
-        return fxaUtils.launchOAuthKeyFlow()
+        return Promise.resolve()
+        .then(() => fxaUtils.launchOAuthKeyFlow())
         .then((loginDetails) => {
           trackEvent('login-success');
           this.props.dispatch(authenticate(loginDetails));

--- a/native/app/components/ListPanel.js
+++ b/native/app/components/ListPanel.js
@@ -283,11 +283,13 @@ class ListPanel extends React.Component {
         <Snackbar
           style={{
             backgroundColor: this.state.snackbar ? this.state.snackbar.color : COLOR_DARK_SYNC,
+            position: 'relative',
+            top: SNACKBAR_HEIGHT,
             transform: [
               {
                 translateY: this.state.fabPositionAnimation.interpolate({
                     inputRange: [0, 1],
-                    outputRange: [SNACKBAR_HEIGHT, 0]
+                    outputRange: [0, -1 * SNACKBAR_HEIGHT]
                   }),
               },
             ],

--- a/native/app/components/LoadingPanel.js
+++ b/native/app/components/LoadingPanel.js
@@ -19,9 +19,8 @@ class LoadingPanel extends React.Component {
 
   componentDidMount() {
 
-    return Promise.resolve().then(() => {
-      return fxaUtils.launchOAuthKeyFlow();
-    }).then((loginDetails) => {
+    return fxaUtils.launchOAuthKeyFlow()
+    .then((loginDetails) => {
       trackEvent('login-success');
       this.props.dispatch(authenticate(loginDetails));
       ToastAndroid.show('Logged in as ' + loginDetails.profile.email, ToastAndroid.LONG);

--- a/native/app/components/LoginPanel.js
+++ b/native/app/components/LoginPanel.js
@@ -4,7 +4,6 @@ import { connect } from 'react-redux';
 import { Button } from 'react-native-paper';
 import { NavigationActions, StackActions } from 'react-navigation';
 import { View, Text, ProgressBarAndroid, ToastAndroid, Image, StyleSheet } from 'react-native';
-import { kintoLoad, disconnect} from '../actions';
 
  import { COLOR_NOTES_BLUE } from '../utils/constants';
  import i18nGetMessage from '../utils/i18n';

--- a/native/app/components/Snackbar.js
+++ b/native/app/components/Snackbar.js
@@ -221,7 +221,7 @@ class Snackbar extends React.Component<Props, State> {
           style,
         ]}
       >
-        <TouchableWithoutFeedback onPress={!action ? onDismiss : null}>
+        <TouchableWithoutFeedback onPress={!action ? () => onDismiss(true) : null}>
           <Animated.View
             style={[
               styles.container,

--- a/native/app/reducers.js
+++ b/native/app/reducers.js
@@ -87,7 +87,7 @@ function sync(sync = {}, action) {
         isOpeningLogin: false,
         isPleaseLogin: false,
         isReconnectSync: true,
-        error: null
+        error: action.message
       });
     case DELETE_NOTE:
       return Object.assign({}, sync, {
@@ -164,6 +164,10 @@ function sync(sync = {}, action) {
 function kinto(kinto = {}, action) {
   switch (action.type) {
     case KINTO_LOADED:
+      return Object.assign({}, kinto, {
+        isLoaded: true
+      });
+    case RECONNECT_SYNC:
       return Object.assign({}, kinto, {
         isLoaded: true
       });

--- a/native/app/utils/sync.js
+++ b/native/app/utils/sync.js
@@ -195,8 +195,7 @@ let lastSyncTimestamp = null;
 function syncKinto(client, loginDetails) {
 
   // If device is offline, we skip syncing.
-  if (store.getState().sync.isConnected === false ||
-      !store.getState().profile.email) return Promise.resolve();
+  if (store.getState().sync.isConnected === false) return Promise.resolve();
 
   if (!loginDetails) { return Promise.reject(); }
 


### PR DESCRIPTION
No longer open the drawer on reconnectSync error. 
Reconnect snackbar has unlimited duration, so will stay on screen until the user click on it to open the login page.
ALSO: reset kinto.js syncStatus on reconnectSync error to push local notes if user reset its password 🎉.

Fix #1066, Fix #1073 