### PR TITLE
Revert "Target SDK 26 in Android"

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -16,7 +16,7 @@ tasks:
       features:
         taskclusterProxy: true
       maxRunTime: 3600
-      image: circleci/android:api-26-node8-alpha
+      image: circleci/android:api-25-node8-alpha
       command:
         - /bin/bash
         - '--login'

--- a/circle.yml
+++ b/circle.yml
@@ -34,7 +34,7 @@ jobs:
   android:
     working_directory: ~/notes/native
     docker:
-      - image: circleci/android:api-26-node8-alpha
+      - image: circleci/android:api-25-node8-alpha
     steps:
       - checkout
 

--- a/native/android/app/build.gradle
+++ b/native/android/app/build.gradle
@@ -100,7 +100,7 @@ android {
     defaultConfig {
         applicationId "org.mozilla.testpilot.notes"
         minSdkVersion 21
-        targetSdkVersion 26
+        targetSdkVersion 22
         versionCode 1
         versionName "1.0android"
         ndk {

--- a/native/android/app/proguard-rules.pro
+++ b/native/android/app/proguard-rules.pro
@@ -68,3 +68,5 @@
 -dontwarn java.nio.file.*
 -dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
 -dontwarn okio.**
+
+-ignorewarnings

--- a/native/android/app/proguard-rules.pro
+++ b/native/android/app/proguard-rules.pro
@@ -68,8 +68,3 @@
 -dontwarn java.nio.file.*
 -dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
 -dontwarn okio.**
-
-
-# There are rules above but they are ignore for some reason in API level 26
-
--ignorewarnings


### PR DESCRIPTION
Reverts mozilla/notes#1117

Fixes https://github.com/mozilla/notes/issues/1118
Fixes https://github.com/mozilla/notes/issues/1119