### PR TITLE
Close menu when sidebar is blurred

### DIFF
--- a/src/sidebar/app/components/Footer.js
+++ b/src/sidebar/app/components/Footer.js
@@ -115,6 +115,14 @@ class Footer extends React.Component {
       }
     };
 
+    // Handle closing of menu when window (Notes sidebar) is blurred
+    // Refs: https://github.com/mozilla/notes/issues/1219
+    window.addEventListener('blur', (e) => {
+      if (this.menu && this.menu.classList.contains('open')) {
+        this.toggleMenu(e);
+      }
+    });
+
     // Handle keyboard navigation on menu
     this.handleKeyPress = (event) => {
       switch (event.key) {

--- a/src/sidebar/app/components/Header.js
+++ b/src/sidebar/app/components/Header.js
@@ -37,6 +37,15 @@ class Header extends React.Component {
       }
     };
 
+    // Handle closing of menu when window (Notes sidebar) is blurred
+    // Refs: https://github.com/mozilla/notes/issues/1219
+    window.addEventListener('blur', (e) => {
+      console.log(this.menu);
+      if (this.menu && this.menu.classList.contains('open')) {
+        this.toggleMenu(e);
+      }
+    });
+
     // Handle keyboard navigation on menu
     this.handleKeyPress = (event) => {
       switch (event.key) {

--- a/src/sidebar/app/components/Header.js
+++ b/src/sidebar/app/components/Header.js
@@ -40,7 +40,6 @@ class Header extends React.Component {
     // Handle closing of menu when window (Notes sidebar) is blurred
     // Refs: https://github.com/mozilla/notes/issues/1219
     window.addEventListener('blur', (e) => {
-      console.log(this.menu);
       if (this.menu && this.menu.classList.contains('open')) {
         this.toggleMenu(e);
       }


### PR DESCRIPTION
Fixes #1219

**Problem:**
When the Header menu is open and a click event is made outside of the Notes sidebar, the menu remains open rather than closing as expected.

**Solution:**
A `blur` event listener is added to the `window` which first checks if the menu is open. If so, then `toggleMenu()` is called which closes the menu when a click outside the sidebar is made.