### PR TITLE
Add logic to sign the APK from circleci

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -96,7 +96,7 @@ jobs:
 
 workflows:
   version: 2
-  node-android:
+  node-android-signapk:
     jobs:
       - webextension
       - android

--- a/circle.yml
+++ b/circle.yml
@@ -65,9 +65,46 @@ jobs:
       - store_artifacts:
           path: /tmp/artifacts-android
 
+      - save_cache:
+          key: apk-v1-{{ .Branch }}-{{epoch}}
+          paths:
+            - /tmp/artifacts-android/app-release.apk
+
+  signapk:
+    working_directory: ~/notes/native
+    docker:
+      - image: circleci/android:api-25-node8-alpha
+    steps:
+      - restore_cache:
+          key: apk-v1-{{ .Branch }}
+      - run:
+          name: Sign APK
+          command: |
+              curl -F "input=@/tmp/artifacts-android/app-release.apk" \
+                    -o /tmp/artifacts-android/app-release-signed.apk \
+                    -H "Authorization: $AUTOGRAPH_EDGE_TOKEN" \
+                    https://autograph-edge.prod.mozaws.net/sign
+      - run:
+          name: Verify APK
+          command: |
+              sudo apt update
+              sudo apt install -y android-sdk-build-tools
+              /opt/android/sdk/build-tools/27.0.3/apksigner verify --verbose /tmp/artifacts-android/app-release-signed.apk
+
+      - store_artifacts:
+          path: /tmp/artifacts-android
+
 workflows:
   version: 2
   node-android:
     jobs:
       - webextension
       - android
+      - signapk:
+          requires:
+            - android
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              only: master


### PR DESCRIPTION
This should automate apk signing for everything pushed to the master branch. You can also require a tag by tweaking that tags.only regex.
I set the env var in circleci already, so it should just work :tm: 