### PR TITLE
Make drag styling the same as system focus

### DIFF
--- a/src/sidebar/static/css/styles-dark.css
+++ b/src/sidebar/static/css/styles-dark.css
@@ -171,12 +171,6 @@ footer.warning button svg path { fill: black !important; }
   background-color: #0080ff;
 }
 
-#notes .drag-n-drop-focus,
-#notes .drag-n-drop-focus .ck-editor__editable {
-  border: 1px solid #ffff00;
-  background-color: #008080;
-}
-
 .listView ul li button p,
 .listView ul li button p span { color: var(--secondary-font-color); }
 

--- a/src/sidebar/static/scss/ckeditor.scss
+++ b/src/sidebar/static/scss/ckeditor.scss
@@ -97,8 +97,15 @@
 
   .drag-n-drop-focus,
   .drag-n-drop-focus .ck-editor__editable {
-    border: 1px solid #008000;
-    background-color: #dcd6da;
+    // `outline` used rather than `border` because:
+    //    outlines never take up space, as they are drawn
+    //    outside of an element's content.
+    // Refs: https://developer.mozilla.org/en-US/docs/Web/CSS/outline#Borders_vs._outlines
+    // This means content will not shift when an outline is applied.
+    // Negative `outline-offset` used to draw outline inside the
+    // element, allowing us to emulate a `border`.
+    outline: rgba(131, 192, 253, 0.5) solid 3px;
+    outline-offset: -3px;
   }
 
   .ck.ck-list .ck-list__item:focus {


### PR DESCRIPTION
Fixes #806

**Problem:**
Drag styling caused a green border to appear which also shifted the content of the notepad, resulting in an unpleasant UX.

**Solution:**
Switching from a CSS `border` to `outline` fixes the issue of content shifting - this no longer occurs because outlines no not take up space. Because outlines are drawn on the outside of elements, a negative `outline-offset` is used to move the outline inside the element, thus emulating a border. Finally, system focus similarity is achieved by using a blue color found on Apple's developer website.

**Demonstration:**
![notes-drag-styling-fix](https://user-images.githubusercontent.com/16343560/42358020-7f693560-808f-11e8-9e62-e60399ecf542.gif)
