### PR TITLE
Fix note title spilling into note summary

### DIFF
--- a/src/sidebar/app/utils/utils.js
+++ b/src/sidebar/app/utils/utils.js
@@ -58,7 +58,7 @@ function getFirstLineFromContent(content) {
     return null;
   }
 
-  return element.textContent.trim().substring(0, 250) || null;
+  return element.textContent.trim() || null;
 }
 
 function stripHtmlWithoutFirstLine(content) {


### PR DESCRIPTION
Fixes #1039

**Problem:**
If the first line of a note was longer than 250 characters in length, the note summary in the notes list view displayed the 250th+ characters as well as the second line. The function for getting the first line of notes content returned the line with a maximum character length of 250 characters (`getFirstLineFromContent()`). The function that utilizes this function compared the return result against the entire notes content as a way to eliminate the first line, but any characters after the 250 mark would be included in the "second line" due to `getFirstLineFromContent()` returning only 250 chars.

**Solution:**
  Removing the `substring(0, 250)` method from `getFirstLineFromContent()` allows for `stripHtmlWithoutFirstLine()` to correctly eliminate the first line from the notes summary.