### PR TITLE
Note creation limited to only non-empty notes

### DIFF
--- a/src/sidebar/app/components/Editor.js
+++ b/src/sidebar/app/components/Editor.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 
 import INITIAL_CONFIG from '../data/editorConfig';
 import { SEND_TO_NOTES, FROM_BLANK_NOTE } from '../utils/constants';
-import { getPadStats, customizeEditor } from '../utils/editor';
+import { getPadStats, customizeEditor, notepadEmpty } from '../utils/editor';
 
 import { updateNote, createNote, deleteNote, setFocusedNote } from '../actions';
 
@@ -61,9 +61,10 @@ class Editor extends React.Component {
             // Only use the focused editor or handle 'rename' events to set the data into storage.
             if (isFocused || name === 'rename' || name === 'insert' || name.type && name.type === 'transparent') {
                 const content = editor.getData();
-
+                const notesContentHTML = document.createElement('div');
+                notesContentHTML.innerHTML = content; // eslint-disable-line no-unsanitized/property
                 if (!this.ignoreChange) {
-                  if (content !== '' && content !== '<p>&nbsp;</p>') {
+                  if (content !== '' && !notepadEmpty(notesContentHTML)) {
                     if (!this.props.note.id) {
                       this.props.dispatch(createNote(content, this.props.origin)).then(id => {
                         this.props.dispatch(setFocusedNote(id));

--- a/src/sidebar/app/utils/editor.js
+++ b/src/sidebar/app/utils/editor.js
@@ -149,4 +149,35 @@ function getPadStats(editor) {
   };
 }
 
-export { customizeEditor, getPadStats };
+/**
+ * Checks if the note's content is empty. Used to determine whether or not
+ * to create a new note.
+ * Source: https://appelgran.org/blog/post/46/javascript-check-if-element-and-childnodes-are-empty
+ * Refs: https://github.com/mozilla/notes/issues/1110
+ * @param {HTMLElement} element
+ * @returns {Boolean}
+ */
+function notepadEmpty(element) {
+  if (element.childNodes.length > 0) {
+    for (let i = 0; i < element.childNodes.length; i++ ) {
+      if (!notepadEmpty(element.childNodes[i])) {
+        return false;
+      }
+    }
+    return true;
+  }
+  let isElementEmpty = false;
+  switch (element.nodeType) {
+    case 1:
+      isElementEmpty = element.innerHTML.trim().length === 0;
+      break;
+    case 3:
+      isElementEmpty = element.textContent.trim().length === 0;
+      break;
+    default:
+      break;
+  }
+  return isElementEmpty;
+}
+
+export { customizeEditor, getPadStats, notepadEmpty };


### PR DESCRIPTION
Fixes #1110

**Problem:**
If a note is empty and a formatting option is applied (e.g. headers, lists), then note creation is initiated. This happens because a note is created if the note's content does not equal `<p>&nbsp;</p>`, which does not cover empty headers (h1, h2, h3) or lists (ol, ul, li).

**Solution:**
Given the notepad's content, we can recursively check if the elements are empty or not by looking at the length of the element's textContent or innerHTML. Now, even if the notepad is empty but one or more styles are applied to the empty space, a note will not be created.