### PR TITLE
Bump version to 4.3.0dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notes",
   "id": "notes@mozilla.com",
   "description": "Displays a sidebar that lets you take notes on web pages.",
-  "version": "4.2.0dev",
+  "version": "4.3.0dev",
   "author": "Test Pilot Mozilla Team",
   "bugs": {
     "url": "https://github.com/mozilla/notes/issues"

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Firefox Notes",
   "description": "Displays a sidebar that lets you take notes on web pages.",
-  "version": "4.2.0dev",
+  "version": "4.3.0dev",
   "default_locale": "en_US",
   "author": "Mozilla Test Pilot team",
   "applications": {


### PR DESCRIPTION
The latest master has the same version number as our released version.
We want to avoid doing this because it can lead to Firefox's auto-update issue where even though you have the latest master installed, you'll get updated to the Test Pilot release version.

We've had issues in the past that were caused by this. See #332 and #339.