### PR TITLE
Split APK into x86 and armv7 flavors

### DIFF
--- a/native/android/app/build.gradle
+++ b/native/android/app/build.gradle
@@ -86,7 +86,7 @@ apply from: "../../node_modules/react-native/react.gradle"
  * Upload all the APKs to the Play Store and people will download
  * the correct one based on the CPU architecture of their device.
  */
-def enableSeparateBuildPerCPUArchitecture = false
+def enableSeparateBuildPerCPUArchitecture = true
 
 /**
  * Run Proguard to shrink the Java bytecode in release builds.
@@ -96,6 +96,7 @@ def enableProguardInReleaseBuilds = true
 android {
     compileSdkVersion 25
     buildToolsVersion "26.0.2"
+    flavorDimensions "abi"
 
     defaultConfig {
         applicationId "org.mozilla.testpilot.notes"
@@ -126,6 +127,14 @@ android {
             enable enableSeparateBuildPerCPUArchitecture
             universalApk false  // If true, also generate a universal APK
             include "armeabi-v7a", "x86"
+        }
+    }
+    productFlavors {
+        x86 {
+            dimension "abi"
+        }
+        armv7 {
+            dimension "abi"
         }
     }
     buildTypes {


### PR DESCRIPTION
APK size without split: 13M
APK w/ split (x86): 9.7M, (armv7): 8.3M

r? @vladikoff 