### PR TITLE
Prevent two sign-in windows from opening on Android

### DIFF
--- a/native/android/app/src/main/AndroidManifest.xml
+++ b/native/android/app/src/main/AndroidManifest.xml
@@ -46,7 +46,8 @@
         </activity>
         <activity
             android:name="com.notes.FxaLoginActivity"
-            android:configChanges="keyboard|keyboardHidden|orientation|screenSize" />
+            android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
+            android:launchMode="singleTop"/>
     </application>
 
 </manifest>


### PR DESCRIPTION
Fixes #1336, #1337

From [Android docs](https://developer.android.com/guide/topics/manifest/activity-element#lmode), `singleTop` allows the activity to receive multiple intent from the base activity without necessarily creating multiple instances.

r? @vladikoff 