### PR TITLE
Bug 1511391 - Fix the extension on Nightly and Beta.

### DIFF
--- a/src/sidebar/static/scss/styles.scss
+++ b/src/sidebar/static/scss/styles.scss
@@ -33,6 +33,11 @@ body > div {
   padding: 0;
 }
 
+html, body {
+  // Override https://searchfox.org/mozilla-central/rev/76fe4bb385348d3f45bbebcf69ba8c7283dfcec7/browser/components/extensions/extension.css#16
+  -moz-user-select: auto;
+}
+
 /**
 Custom list types for indents
 https://github.com/mozilla/notes/issues/413


### PR DESCRIPTION
For some reason the UA sheet loaded for extensions has a -moz-user-select: none
rule.

I have absolutely no clue why it's there, the commit message that introduced it
doesn't explain much.

In any case this is a very low-risk fix for the extension.