### PR TITLE
Fix crash from AndroidX in development

### DIFF
--- a/native/android/app/src/main/java/com/notes/FxaLoginActivity.java
+++ b/native/android/app/src/main/java/com/notes/FxaLoginActivity.java
@@ -5,7 +5,7 @@ import android.content.Intent;
 import android.graphics.Bitmap;
 import android.net.Uri;
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
+import androidx.appcompat.app.AppCompatActivity;
 import android.webkit.CookieManager;
 import android.webkit.WebStorage;
 import android.webkit.WebView;

--- a/native/android/gradle.properties
+++ b/native/android/gradle.properties
@@ -19,3 +19,5 @@
 
 android.useDeprecatedNdk=true
 #android.enableAapt2=false
+android.useAndroidX=true
+android.enableJetifier=true

--- a/native/package-lock.json
+++ b/native/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "Notes",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8210,7 +8210,7 @@
       }
     },
     "rn-nodeify": {
-      "version": "github:tradle/rn-nodeify#86763a2e44f80b2089eae13ca3593260a93aac16",
+      "version": "github:tradle/rn-nodeify#300ca4460c3e4ffa01c45b3a122ce182dc1a0c5a",
       "from": "github:tradle/rn-nodeify",
       "dev": true,
       "requires": {


### PR DESCRIPTION
The app can't be launched in dev mode without AndroidX.

To fix this we can enable these two options:
* `enableJetifier` => Jetifier is a tool to help project transition to AndroidX
* `useAndroidX` => Activates AndroidX